### PR TITLE
feat(process): tmux-based process manager backend

### DIFF
--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -5,6 +5,16 @@ use std::path::PathBuf;
 use anyhow::Context;
 use serde::Deserialize;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessBackend {
+    /// Use tmux if available, else fall back to direct spawn.
+    Auto,
+    /// Require tmux; fail if missing.
+    Tmux,
+    /// Current behavior, no tmux.
+    Direct,
+}
+
 /// Directory name component used in all default paths.
 /// Debug builds use "coulson-dev" for isolation from release installs.
 #[cfg(debug_assertions)]
@@ -55,6 +65,7 @@ pub struct CoulsonConfig {
     pub inspect_max_requests: usize,
     pub certs_dir: PathBuf,
     pub runtime_dir: PathBuf,
+    pub process_backend: ProcessBackend,
 }
 
 impl Default for CoulsonConfig {
@@ -91,6 +102,7 @@ impl Default for CoulsonConfig {
             inspect_max_requests: 200,
             certs_dir: xdg_config_home().join(format!("{DIR_NAME}/certs")),
             runtime_dir,
+            process_backend: ProcessBackend::Auto,
         }
     }
 }
@@ -137,6 +149,10 @@ impl CoulsonConfig {
         }
         if let Some(ref v) = file.runtime_dir {
             cfg.runtime_dir = expand_tilde(v);
+        }
+        if let Some(ref v) = file.process_backend {
+            cfg.process_backend = parse_process_backend(v)
+                .with_context(|| format!("invalid process_backend in config.toml: {v}"))?;
         }
 
         // Layer 3: Environment variables (highest priority)
@@ -189,6 +205,10 @@ impl CoulsonConfig {
         if let Ok(path) = env::var("COULSON_RUNTIME_DIR") {
             cfg.runtime_dir = PathBuf::from(&path);
         }
+        if let Ok(raw) = env::var("COULSON_PROCESS_BACKEND") {
+            cfg.process_backend = parse_process_backend(&raw)
+                .with_context(|| format!("invalid COULSON_PROCESS_BACKEND: {raw}"))?;
+        }
 
         // HTTPS listener: env > toml > default
         if let Ok(raw) = env::var("COULSON_LISTEN_HTTPS") {
@@ -222,6 +242,15 @@ impl CoulsonConfig {
         }
 
         Ok(cfg)
+    }
+}
+
+fn parse_process_backend(input: &str) -> anyhow::Result<ProcessBackend> {
+    match input.trim().to_ascii_lowercase().as_str() {
+        "auto" => Ok(ProcessBackend::Auto),
+        "tmux" => Ok(ProcessBackend::Tmux),
+        "direct" => Ok(ProcessBackend::Direct),
+        _ => anyhow::bail!("expected auto, tmux, or direct"),
     }
 }
 
@@ -275,6 +304,7 @@ struct ConfigFile {
     inspect_max_requests: Option<usize>,
     certs_dir: Option<String>,
     runtime_dir: Option<String>,
+    process_backend: Option<String>,
 }
 
 impl ConfigFile {

--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -428,6 +428,10 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
         }
         "app.delete" => {
             let params: AppIdParams = parse_params!(req);
+            // Stop managed process before deleting
+            let mut pm = state.process_manager.lock().await;
+            pm.kill_process(params.app_id).await;
+            drop(pm);
             service::app_delete(state, params.app_id)
                 .map(|_| json!({ "deleted": true }))
                 .map_err(ControlError::from)

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -253,6 +253,11 @@ enum Commands {
         #[arg(long)]
         pf: bool,
     },
+    /// Attach to a managed process's tmux session (Ctrl-B D to detach)
+    Attach {
+        /// App name or domain (omit to match CWD)
+        name: Option<String>,
+    },
     /// Manage tunnels
     Tunnel {
         #[command(subcommand)]
@@ -353,8 +358,12 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
     let (network_change_tx, _) = broadcast::channel(4);
     let idle_timeout = Duration::from_secs(cfg.idle_timeout_secs);
     let registry = Arc::new(process::default_registry());
-    let process_manager =
-        process::new_process_manager(idle_timeout, Arc::clone(&registry), cfg.runtime_dir.clone());
+    let process_manager = process::new_process_manager(
+        idle_timeout,
+        Arc::clone(&registry),
+        cfg.runtime_dir.clone(),
+        cfg.process_backend,
+    );
 
     Ok(SharedState {
         store,
@@ -643,6 +652,44 @@ fn run_doctor(cfg: CoulsonConfig, check_pf: bool) -> anyhow::Result<()> {
         #[cfg(not(target_os = "macos"))]
         {
             print_check(true, "pf check skipped (not macOS)");
+        }
+    }
+
+    // 10. tmux process backend
+    {
+        use crate::config::ProcessBackend;
+        let tmux_path = std::process::Command::new("which")
+            .arg("tmux")
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+        match (tmux_path, cfg.process_backend) {
+            (Some(path), _) => {
+                let version = std::process::Command::new("tmux")
+                    .arg("-V")
+                    .output()
+                    .ok()
+                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                    .unwrap_or_default();
+                let backend_label = match cfg.process_backend {
+                    ProcessBackend::Auto => "auto → tmux",
+                    ProcessBackend::Tmux => "tmux",
+                    ProcessBackend::Direct => "direct (tmux available but not used)",
+                };
+                print_check(
+                    true,
+                    &format!("tmux: {version} ({path}), backend: {backend_label}"),
+                );
+            }
+            (None, ProcessBackend::Tmux) => {
+                print_check(false, "tmux not found but COULSON_PROCESS_BACKEND=tmux");
+                issues += 1;
+            }
+            (None, _) => {
+                print_check(true, "tmux not found, using direct process backend");
+            }
         }
     }
 
@@ -1178,6 +1225,7 @@ async fn main() -> anyhow::Result<()> {
         } => run_logs(cfg, name, follow, lines),
         Commands::Ps => run_ps(cfg),
         Commands::Restart { name } => run_restart(cfg, name),
+        Commands::Attach { name } => run_attach(cfg, name),
         Commands::Trust { pf } => run_trust(cfg, pf),
         Commands::Tunnel { action } => run_tunnel(cfg, action),
     }
@@ -1894,6 +1942,42 @@ fn run_restart(cfg: CoulsonConfig, name: Option<String>) -> anyhow::Result<()> {
     client.call("process.restart", serde_json::json!({ "app_id": app_id }))?;
     println!("{} {bare_name} restarted", "✓".green());
     Ok(())
+}
+
+fn run_attach(cfg: CoulsonConfig, name: Option<String>) -> anyhow::Result<()> {
+    use crate::config::ProcessBackend;
+
+    if cfg.process_backend == ProcessBackend::Direct {
+        bail!("attach requires tmux backend (set COULSON_PROCESS_BACKEND=auto or tmux)");
+    }
+
+    if !process::tmux_available() {
+        bail!("tmux not found in PATH");
+    }
+
+    let bare_name = resolve_app_name(&cfg, name.as_deref())?;
+    let session_name = bare_name.clone();
+
+    // Check if the tmux session exists
+    let status = std::process::Command::new("tmux")
+        .args(["-L", "coulson", "has-session", "-t", &session_name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+
+    if !status.success() {
+        bail!(
+            "no tmux session for '{bare_name}' (process may not be running or using direct backend)"
+        );
+    }
+
+    // Replace current process with tmux attach
+    use std::os::unix::process::CommandExt;
+    let err = std::process::Command::new("tmux")
+        .args(["-L", "coulson", "attach-session", "-t", &session_name])
+        .exec();
+    // exec() only returns on error
+    bail!("failed to exec tmux: {err}");
 }
 
 fn format_duration(secs: u64) -> String {

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -15,11 +15,15 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use tokio::process::{Child, Command};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use std::process::Stdio;
 
+use crate::config::ProcessBackend;
 use provider::{ManagedApp, ProcessSpec};
+
+/// Dedicated tmux socket name — isolates coulson sessions from user's own tmux.
+const TMUX_SOCKET: &str = "coulson";
 
 pub type ProcessManagerHandle = Arc<tokio::sync::Mutex<ProcessManager>>;
 
@@ -27,11 +31,13 @@ pub fn new_process_manager(
     idle_timeout: Duration,
     registry: Arc<ProviderRegistry>,
     runtime_dir: PathBuf,
+    backend: ProcessBackend,
 ) -> ProcessManagerHandle {
     Arc::new(tokio::sync::Mutex::new(ProcessManager::new(
         idle_timeout,
         registry,
         runtime_dir,
+        backend,
     )))
 }
 
@@ -46,21 +52,26 @@ pub fn default_registry() -> ProviderRegistry {
     reg
 }
 
+enum ProcessHandle {
+    Direct { child: Child },
+    Tmux { session_name: String },
+}
+
+struct ManagedProcess {
+    handle: ProcessHandle,
+    listen_target: ListenTarget,
+    started_at: Instant,
+    last_active: Instant,
+    kind: String,
+    ready: bool,
+}
+
 pub struct ProcessManager {
     processes: HashMap<i64, ManagedProcess>,
     idle_timeout: Duration,
     registry: Arc<ProviderRegistry>,
     runtime_dir: PathBuf,
-}
-
-struct ManagedProcess {
-    child: Child,
-    listen_target: ListenTarget,
-    started_at: Instant,
-    last_active: Instant,
-    #[allow(dead_code)]
-    kind: String,
-    ready: bool,
+    use_tmux: bool,
 }
 
 pub enum StartStatus {
@@ -79,6 +90,7 @@ pub struct ProcessInfo {
     pub uptime_secs: u64,
     pub idle_secs: u64,
     pub alive: bool,
+    pub backend: String,
 }
 
 impl ProcessManager {
@@ -86,13 +98,39 @@ impl ProcessManager {
         idle_timeout: Duration,
         registry: Arc<ProviderRegistry>,
         runtime_dir: PathBuf,
+        backend: ProcessBackend,
     ) -> Self {
+        let use_tmux = match backend {
+            ProcessBackend::Tmux => {
+                if !tmux_available() {
+                    warn!("COULSON_PROCESS_BACKEND=tmux but tmux not found in PATH");
+                }
+                true
+            }
+            ProcessBackend::Direct => false,
+            ProcessBackend::Auto => {
+                let available = tmux_available();
+                if available {
+                    info!("tmux found, using tmux process backend");
+                } else {
+                    info!("tmux not found, using direct process backend");
+                }
+                available
+            }
+        };
+
         Self {
             processes: HashMap::new(),
             idle_timeout,
             registry,
             runtime_dir,
+            use_tmux,
         }
+    }
+
+    /// Whether the tmux backend is active.
+    pub fn uses_tmux(&self) -> bool {
+        self.use_tmux
     }
 
     pub fn list_status(&mut self) -> Vec<ProcessInfo> {
@@ -100,23 +138,37 @@ impl ProcessManager {
         self.processes
             .iter_mut()
             .map(|(app_id, proc)| {
-                let alive = matches!(proc.child.try_wait(), Ok(None));
+                let (pid, alive, backend) = match &mut proc.handle {
+                    ProcessHandle::Direct { child } => {
+                        let pid = child.id().unwrap_or(0);
+                        let alive = matches!(child.try_wait(), Ok(None));
+                        (pid, alive, "direct")
+                    }
+                    ProcessHandle::Tmux { session_name } => {
+                        let pid = tmux_pane_pid(session_name).unwrap_or(0);
+                        let alive = if pid != 0 {
+                            tmux_pane_alive(session_name)
+                        } else {
+                            false
+                        };
+                        (pid, alive, "tmux")
+                    }
+                };
                 ProcessInfo {
                     app_id: *app_id,
-                    pid: proc.child.id().unwrap_or(0),
+                    pid,
                     kind: proc.kind.clone(),
                     listen_address: listen_target_display(&proc.listen_target),
                     uptime_secs: now.duration_since(proc.started_at).as_secs(),
                     idle_secs: now.duration_since(proc.last_active).as_secs(),
                     alive,
+                    backend: backend.to_string(),
                 }
             })
             .collect()
     }
 
     /// Returns the listen target for the managed app, starting the process if needed.
-    ///
-    /// The `kind` parameter selects the provider (e.g. "asgi", "rack", "node").
     pub async fn ensure_running(
         &mut self,
         app_id: i64,
@@ -126,78 +178,30 @@ impl ProcessManager {
     ) -> anyhow::Result<ListenTarget> {
         // Check if already running and alive
         if let Some(proc) = self.processes.get_mut(&app_id) {
-            match proc.child.try_wait() {
-                Ok(None) => {
-                    proc.last_active = Instant::now();
-                    return Ok(proc.listen_target.clone());
-                }
-                _ => {
-                    info!(app_id, "managed process exited, will restart");
-                    let removed = self.processes.remove(&app_id).unwrap();
-                    cleanup_listen_target(&removed.listen_target);
-                }
+            if is_alive(&mut proc.handle) {
+                proc.last_active = Instant::now();
+                return Ok(proc.listen_target.clone());
             }
+            info!(app_id, "managed process exited, will restart");
+            let removed = self.processes.remove(&app_id).unwrap();
+            kill_handle(removed.handle).await;
+            cleanup_listen_target(&removed.listen_target);
         }
 
-        // Resolve the provider
-        let prov = self
-            .registry
-            .get(kind)
-            .ok_or_else(|| anyhow::anyhow!("no process provider for kind: {kind}"))?;
-
-        let managed_dir = self.runtime_dir.join("managed");
-        std::fs::create_dir_all(&managed_dir)
-            .with_context(|| format!("failed to create {}", managed_dir.display()))?;
-        // On macOS /tmp → /private/tmp; canonicalize so pingora's peer address matches.
-        let sockets_dir = std::fs::canonicalize(&managed_dir).unwrap_or(managed_dir);
-
-        let managed_app = ManagedApp {
-            name: name.to_string(),
-            root: root.to_path_buf(),
-            kind: kind.to_string(),
-            manifest: None,
-            env_overrides: HashMap::new(),
-            socket_dir: sockets_dir.clone(),
-        };
-
-        let spec: ProcessSpec = prov.resolve(&managed_app)?;
+        let (spec, sockets_dir, prov_name) = self.resolve_spec(app_id, name, root, kind)?;
 
         info!(
             app_id,
             kind,
             listen = %listen_target_display(&spec.listen_target),
-            command = %spec.command.display(),
             root = %root.display(),
-            "starting managed process via {} provider",
-            prov.display_name()
+            "starting managed process via {prov_name} provider",
         );
 
         cleanup_listen_target(&spec.listen_target);
 
         let log_path = sockets_dir.join(format!("{name}.log"));
-        let log_file = std::fs::File::create(&log_path)
-            .with_context(|| format!("failed to create log file {}", log_path.display()))?;
-        let stderr_file = log_file
-            .try_clone()
-            .with_context(|| "failed to clone log file handle")?;
-
-        let mut cmd = Command::new(&spec.command);
-        cmd.args(&spec.args);
-        for (k, v) in &spec.env {
-            cmd.env(k, v);
-        }
-        // SAFETY: process_group(0) places the child in a new process group (PGID = child PID).
-        // This lets us kill the entire tree (including grandchildren from dev servers).
-        cmd.process_group(0);
-
-        let child = cmd
-            .current_dir(&spec.working_dir)
-            .kill_on_drop(true)
-            .stdin(Stdio::null())
-            .stdout(stderr_file)
-            .stderr(log_file)
-            .spawn()
-            .with_context(|| format!("failed to spawn {} for {app_id}", spec.command.display()))?;
+        let handle = self.spawn_process(name, &spec, &log_path, &sockets_dir)?;
 
         const READY_TIMEOUT_SECS: u64 = 30;
         wait_for_ready(&spec.listen_target, Duration::from_secs(READY_TIMEOUT_SECS)).await?;
@@ -206,7 +210,7 @@ impl ProcessManager {
         self.processes.insert(
             app_id,
             ManagedProcess {
-                child,
+                handle,
                 listen_target: spec.listen_target.clone(),
                 started_at: now,
                 last_active: now,
@@ -219,8 +223,6 @@ impl ProcessManager {
     }
 
     /// Non-blocking variant: spawns the process if needed but does NOT wait for readiness.
-    /// Returns `StartStatus::Ready` if the process is running and connectable,
-    /// or `StartStatus::Starting` if the process has been spawned but isn't ready yet.
     pub async fn ensure_started(
         &mut self,
         app_id: i64,
@@ -229,100 +231,55 @@ impl ProcessManager {
         kind: &str,
     ) -> anyhow::Result<StartStatus> {
         if let Some(proc) = self.processes.get_mut(&app_id) {
-            match proc.child.try_wait() {
-                Ok(None) => {
-                    if proc.ready {
-                        proc.last_active = Instant::now();
-                        return Ok(StartStatus::Ready(proc.listen_target.clone()));
-                    }
-                    // Not yet marked ready — probe
-                    if quick_ready_check(&proc.listen_target).await {
-                        proc.ready = true;
-                        proc.last_active = Instant::now();
-                        return Ok(StartStatus::Ready(proc.listen_target.clone()));
-                    }
-                    // Still not ready — check startup timeout
-                    const STARTUP_TIMEOUT_SECS: u64 = 30;
-                    if proc.started_at.elapsed() > Duration::from_secs(STARTUP_TIMEOUT_SECS) {
-                        kill_process_group(&mut proc.child).await;
-                        let removed = self.processes.remove(&app_id).unwrap();
-                        cleanup_listen_target(&removed.listen_target);
-                        anyhow::bail!(
-                            "managed process for {name} (app_id={app_id}) failed to become ready within {STARTUP_TIMEOUT_SECS}s"
-                        );
-                    }
-                    return Ok(StartStatus::Starting);
+            if is_alive(&mut proc.handle) {
+                if proc.ready {
+                    proc.last_active = Instant::now();
+                    return Ok(StartStatus::Ready(proc.listen_target.clone()));
                 }
-                _ => {
-                    info!(app_id, "managed process exited, will restart");
+                // Not yet marked ready — probe
+                if quick_ready_check(&proc.listen_target).await {
+                    proc.ready = true;
+                    proc.last_active = Instant::now();
+                    return Ok(StartStatus::Ready(proc.listen_target.clone()));
+                }
+                // Still not ready — check startup timeout
+                const STARTUP_TIMEOUT_SECS: u64 = 30;
+                if proc.started_at.elapsed() > Duration::from_secs(STARTUP_TIMEOUT_SECS) {
                     let removed = self.processes.remove(&app_id).unwrap();
+                    kill_handle(removed.handle).await;
                     cleanup_listen_target(&removed.listen_target);
+                    anyhow::bail!(
+                        "managed process for {name} (app_id={app_id}) failed to become ready within {STARTUP_TIMEOUT_SECS}s"
+                    );
                 }
+                return Ok(StartStatus::Starting);
             }
+            info!(app_id, "managed process exited, will restart");
+            let removed = self.processes.remove(&app_id).unwrap();
+            kill_handle(removed.handle).await;
+            cleanup_listen_target(&removed.listen_target);
         }
 
-        // Spawn a new process (same as ensure_running but skip readiness wait)
-        let prov = self
-            .registry
-            .get(kind)
-            .ok_or_else(|| anyhow::anyhow!("no process provider for kind: {kind}"))?;
-
-        let managed_dir = self.runtime_dir.join("managed");
-        std::fs::create_dir_all(&managed_dir)
-            .with_context(|| format!("failed to create {}", managed_dir.display()))?;
-        let sockets_dir = std::fs::canonicalize(&managed_dir).unwrap_or(managed_dir);
-
-        let managed_app = ManagedApp {
-            name: name.to_string(),
-            root: root.to_path_buf(),
-            kind: kind.to_string(),
-            manifest: None,
-            env_overrides: HashMap::new(),
-            socket_dir: sockets_dir.clone(),
-        };
-
-        let spec: ProcessSpec = prov.resolve(&managed_app)?;
+        let (spec, sockets_dir, prov_name) = self.resolve_spec(app_id, name, root, kind)?;
 
         info!(
             app_id,
             kind,
             listen = %listen_target_display(&spec.listen_target),
-            command = %spec.command.display(),
             root = %root.display(),
-            "starting managed process via {} provider (non-blocking)",
-            prov.display_name()
+            "starting managed process via {prov_name} provider (non-blocking)",
         );
 
         cleanup_listen_target(&spec.listen_target);
 
         let log_path = sockets_dir.join(format!("{name}.log"));
-        let log_file = std::fs::File::create(&log_path)
-            .with_context(|| format!("failed to create log file {}", log_path.display()))?;
-        let stderr_file = log_file
-            .try_clone()
-            .with_context(|| "failed to clone log file handle")?;
-
-        let mut cmd = Command::new(&spec.command);
-        cmd.args(&spec.args);
-        for (k, v) in &spec.env {
-            cmd.env(k, v);
-        }
-        cmd.process_group(0);
-
-        let child = cmd
-            .current_dir(&spec.working_dir)
-            .kill_on_drop(true)
-            .stdin(Stdio::null())
-            .stdout(stderr_file)
-            .stderr(log_file)
-            .spawn()
-            .with_context(|| format!("failed to spawn {} for {app_id}", spec.command.display()))?;
+        let handle = self.spawn_process(name, &spec, &log_path, &sockets_dir)?;
 
         let now = Instant::now();
         self.processes.insert(
             app_id,
             ManagedProcess {
-                child,
+                handle,
                 listen_target: spec.listen_target,
                 started_at: now,
                 last_active: now,
@@ -336,9 +293,9 @@ impl ProcessManager {
 
     /// Kill a specific managed process. Returns true if it was found and killed.
     pub async fn kill_process(&mut self, app_id: i64) -> bool {
-        if let Some(mut proc) = self.processes.remove(&app_id) {
+        if let Some(proc) = self.processes.remove(&app_id) {
             info!(app_id, "killing managed process");
-            kill_process_group(&mut proc.child).await;
+            kill_handle(proc.handle).await;
             cleanup_listen_target(&proc.listen_target);
             true
         } else {
@@ -365,13 +322,13 @@ impl ProcessManager {
         }
 
         for app_id in &to_remove {
-            if let Some(mut proc) = self.processes.remove(app_id) {
+            if let Some(proc) = self.processes.remove(app_id) {
                 info!(
                     app_id,
                     listen = %listen_target_display(&proc.listen_target),
                     "reaping idle managed process"
                 );
-                kill_process_group(&mut proc.child).await;
+                kill_handle(proc.handle).await;
                 cleanup_listen_target(&proc.listen_target);
             }
         }
@@ -381,20 +338,337 @@ impl ProcessManager {
 
     /// Kill all managed processes (called on daemon shutdown).
     pub async fn shutdown_all(&mut self) {
-        for (app_id, mut proc) in self.processes.drain() {
+        for (app_id, proc) in self.processes.drain() {
             info!(
                 app_id,
                 listen = %listen_target_display(&proc.listen_target),
                 "shutting down managed process"
             );
-            kill_process_group(&mut proc.child).await;
+            kill_handle(proc.handle).await;
             cleanup_listen_target(&proc.listen_target);
+        }
+        // If using tmux, kill the dedicated server to clean up.
+        if self.use_tmux {
+            let _ = tmux_cmd().args(["kill-server"]).output();
+        }
+    }
+
+    /// Resolve a ProcessSpec from the provider registry.
+    fn resolve_spec(
+        &self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+    ) -> anyhow::Result<(ProcessSpec, PathBuf, String)> {
+        let prov = self
+            .registry
+            .get(kind)
+            .ok_or_else(|| anyhow::anyhow!("no process provider for kind: {kind}"))?;
+
+        let managed_dir = self.runtime_dir.join("managed");
+        std::fs::create_dir_all(&managed_dir)
+            .with_context(|| format!("failed to create {}", managed_dir.display()))?;
+        let sockets_dir = std::fs::canonicalize(&managed_dir).unwrap_or(managed_dir);
+
+        let managed_app = ManagedApp {
+            name: name.to_string(),
+            root: root.to_path_buf(),
+            kind: kind.to_string(),
+            manifest: None,
+            env_overrides: HashMap::new(),
+            socket_dir: sockets_dir.clone(),
+        };
+
+        let spec = prov.resolve(&managed_app)?;
+        let _ = app_id; // used in caller for logging
+        Ok((spec, sockets_dir, prov.display_name().to_string()))
+    }
+
+    /// Spawn a process using the current backend (direct or tmux).
+    fn spawn_process(
+        &self,
+        name: &str,
+        spec: &ProcessSpec,
+        log_path: &Path,
+        managed_dir: &Path,
+    ) -> anyhow::Result<ProcessHandle> {
+        if self.use_tmux {
+            self.spawn_tmux(name, spec, log_path, managed_dir)
+        } else {
+            Self::spawn_direct(name, spec, log_path)
+        }
+    }
+
+    /// Spawn via direct child process (original behavior).
+    fn spawn_direct(
+        name: &str,
+        spec: &ProcessSpec,
+        log_path: &Path,
+    ) -> anyhow::Result<ProcessHandle> {
+        let log_file = std::fs::File::create(log_path)
+            .with_context(|| format!("failed to create log file {}", log_path.display()))?;
+        let stderr_file = log_file
+            .try_clone()
+            .with_context(|| "failed to clone log file handle")?;
+
+        // All specs go through login shell for user env loading
+        let full_cmd = build_full_command(spec);
+        let (command, args) = login_shell_args(&full_cmd);
+
+        let mut cmd = Command::new(&command);
+        cmd.args(&args);
+        for (k, v) in &spec.env {
+            cmd.env(k, v);
+        }
+        cmd.process_group(0);
+
+        let child = cmd
+            .current_dir(&spec.working_dir)
+            .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(stderr_file)
+            .stderr(log_file)
+            .spawn()
+            .with_context(|| format!("failed to spawn {} for {name}", command.display()))?;
+
+        Ok(ProcessHandle::Direct { child })
+    }
+
+    /// Spawn via tmux session.
+    fn spawn_tmux(
+        &self,
+        name: &str,
+        spec: &ProcessSpec,
+        log_path: &Path,
+        managed_dir: &Path,
+    ) -> anyhow::Result<ProcessHandle> {
+        let session_name = name.to_string();
+
+        // Kill any existing session with this name
+        if tmux_has_session(&session_name) {
+            tmux_kill_session(&session_name);
+        }
+
+        // Generate wrapper script
+        let script_path = managed_dir.join(format!("{name}.sh"));
+        let script_content = generate_wrapper_script(spec);
+        std::fs::write(&script_path, &script_content)
+            .with_context(|| format!("failed to write wrapper script {}", script_path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))?;
+        }
+
+        // Create tmux session
+        let output = tmux_cmd()
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-c",
+                &spec.working_dir.to_string_lossy(),
+                &script_path.to_string_lossy(),
+            ])
+            .output()
+            .with_context(|| format!("failed to spawn tmux session for {name}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux new-session failed: {stderr}");
+        }
+
+        // Set remain-on-exit so session stays for inspection after crash
+        let _ = tmux_cmd()
+            .args(["set-option", "-t", &session_name, "remain-on-exit", "on"])
+            .output();
+
+        // Pipe pane output to log file
+        let _ = tmux_cmd()
+            .args([
+                "pipe-pane",
+                "-t",
+                &session_name,
+                "-o",
+                &format!("cat >> {}", log_path.display()),
+            ])
+            .output();
+
+        debug!(session = %session_name, "spawned tmux session");
+
+        Ok(ProcessHandle::Tmux { session_name })
+    }
+}
+
+/// Build the full shell command string from a ProcessSpec.
+/// Procfile specs have an empty command and a single args element (the raw shell command).
+/// ASGI/Node specs have a binary command and separate args.
+fn build_full_command(spec: &ProcessSpec) -> String {
+    if spec.command.as_os_str().is_empty() {
+        // Procfile-style: args[0] is the complete shell command string
+        spec.args[0].clone()
+    } else {
+        // Binary + args: join into a single command line
+        let mut parts = vec![shell_escape_path(&spec.command)];
+        parts.extend(spec.args.iter().map(|a| shell_escape(a)));
+        parts.join(" ")
+    }
+}
+
+/// Generate a wrapper script for the process.
+fn generate_wrapper_script(spec: &ProcessSpec) -> String {
+    let mut lines = vec!["#!/usr/bin/env sh".to_string()];
+
+    // Export env vars
+    for (k, v) in &spec.env {
+        let escaped = v.replace('\'', "'\\''");
+        lines.push(format!("export {k}='{escaped}'"));
+    }
+
+    let shell = user_shell();
+    let cmd = build_full_command(spec);
+    let escaped_cmd = cmd.replace('\'', "'\\''");
+    lines.push(format!("exec {} -li -c '{}'", shell.display(), escaped_cmd));
+
+    lines.push(String::new()); // trailing newline
+    lines.join("\n")
+}
+
+/// Shell-escape a string with single quotes.
+fn shell_escape(s: &str) -> String {
+    if s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '/' || c == ':'
+    }) {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+fn shell_escape_path(p: &Path) -> String {
+    shell_escape(&p.to_string_lossy())
+}
+
+/// Get the user's login shell from `$SHELL`, falling back to `/bin/sh`.
+fn user_shell() -> PathBuf {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/bin/sh"))
+}
+
+/// Build login-shell arguments that source the interactive RC file before
+/// executing `cmd`. Used by Direct mode to load user env.
+fn login_shell_args(cmd: &str) -> (PathBuf, Vec<String>) {
+    let shell = user_shell();
+    let name = shell.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let full_cmd = match name {
+        "zsh" => format!(". ~/.zshrc 2>/dev/null; {cmd}"),
+        "bash" => format!(". ~/.bashrc 2>/dev/null; {cmd}"),
+        _ => cmd.to_string(),
+    };
+    (shell, vec!["-l".to_string(), "-c".to_string(), full_cmd])
+}
+
+/// Check whether the process handle is still alive.
+fn is_alive(handle: &mut ProcessHandle) -> bool {
+    match handle {
+        ProcessHandle::Direct { child } => matches!(child.try_wait(), Ok(None)),
+        ProcessHandle::Tmux { session_name } => {
+            tmux_has_session(session_name) && tmux_pane_alive(session_name)
         }
     }
 }
 
+/// Kill a process handle.
+async fn kill_handle(handle: ProcessHandle) {
+    match handle {
+        ProcessHandle::Direct { mut child } => {
+            kill_process_group(&mut child).await;
+        }
+        ProcessHandle::Tmux { session_name } => {
+            // SIGTERM the pane process first, then kill the session
+            if let Some(pid) = tmux_pane_pid(&session_name) {
+                let pgid = pid as i32;
+                unsafe { libc::kill(-pgid, libc::SIGTERM) };
+                const GRACE_MS: u64 = 500;
+                tokio::time::sleep(Duration::from_millis(GRACE_MS)).await;
+                // Force kill if still alive
+                unsafe { libc::kill(-pgid, libc::SIGKILL) };
+            }
+            tmux_kill_session(&session_name);
+        }
+    }
+}
+
+// tmux helper functions
+
+/// Check if tmux is available in PATH.
+pub fn tmux_available() -> bool {
+    std::process::Command::new("tmux")
+        .arg("-V")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Build a tmux command with the dedicated socket.
+fn tmux_cmd() -> std::process::Command {
+    let mut cmd = std::process::Command::new("tmux");
+    cmd.args(["-L", TMUX_SOCKET]);
+    cmd
+}
+
+/// Check if a tmux session exists.
+fn tmux_has_session(name: &str) -> bool {
+    tmux_cmd()
+        .args(["has-session", "-t", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Check if the pane process in a tmux session is still alive.
+/// With `remain-on-exit on`, the session persists after the pane process exits.
+fn tmux_pane_alive(name: &str) -> bool {
+    let output = tmux_cmd()
+        .args(["list-panes", "-t", name, "-F", "#{pane_dead}"])
+        .output();
+    match output {
+        Ok(out) => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            // pane_dead is "0" if alive, "1" if dead
+            text.trim() == "0"
+        }
+        Err(_) => false,
+    }
+}
+
+/// Get the PID of the process running in a tmux session's pane.
+fn tmux_pane_pid(name: &str) -> Option<u32> {
+    let output = tmux_cmd()
+        .args(["list-panes", "-t", name, "-F", "#{pane_pid}"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.trim().parse().ok()
+}
+
+/// Kill a tmux session.
+fn tmux_kill_session(name: &str) {
+    let _ = tmux_cmd()
+        .args(["kill-session", "-t", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
 /// Clean up resources associated with a listen target.
-/// Only UDS targets have socket files to remove.
 fn cleanup_listen_target(target: &ListenTarget) {
     if let ListenTarget::Uds(path) = target {
         let _ = std::fs::remove_file(path);
@@ -439,33 +713,23 @@ fn listen_target_display(target: &ListenTarget) -> String {
 }
 
 /// Kill an entire process group: SIGTERM first, then SIGKILL after a grace period.
-///
-/// Dev-mode processes (e.g. `bun run dev`, `npm run dev`) typically spawn child
-/// processes. Using `process_group(0)` when spawning places the entire tree in a
-/// new process group whose PGID equals the child PID. This function sends signals
-/// to the negative PGID, reaching all descendants.
 async fn kill_process_group(child: &mut Child) {
     let Some(pid) = child.id() else {
-        // Already exited.
         return;
     };
     let pgid = pid as i32;
 
-    // SIGTERM the whole group for graceful shutdown.
     let ret = unsafe { libc::kill(-pgid, libc::SIGTERM) };
     if ret != 0 {
-        // Process (group) may already be gone — fall back to direct kill.
         let _ = child.start_kill();
         return;
     }
 
-    // Give a short grace period, then SIGKILL if still alive.
     const GRACE_MS: u64 = 500;
     tokio::time::sleep(Duration::from_millis(GRACE_MS)).await;
 
     match child.try_wait() {
         Ok(None) => {
-            // Still running — force kill the group.
             let ret = unsafe { libc::kill(-pgid, libc::SIGKILL) };
             if ret != 0 {
                 warn!(pid, "SIGKILL to process group failed, trying direct kill");
@@ -473,14 +737,9 @@ async fn kill_process_group(child: &mut Child) {
             }
         }
         Ok(Some(_)) => {
-            // Leader exited but grandchildren may remain in the process group.
-            // PGID stays valid while any member is alive; if all exited,
-            // kill() harmlessly returns ESRCH.
             unsafe { libc::kill(-pgid, libc::SIGKILL) };
         }
         Err(e) => {
-            // Cannot determine process state — skip group signal to avoid
-            // potential misfire on a recycled PGID.
             warn!(pid, error = %e, "failed to check process status, skipping group kill");
         }
     }

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -17,6 +17,8 @@ use anyhow::Context;
 use tokio::process::{Child, Command};
 use tracing::{info, warn};
 
+use std::process::Stdio;
+
 use provider::{ManagedApp, ProcessSpec};
 
 pub type ProcessManagerHandle = Arc<tokio::sync::Mutex<ProcessManager>>;
@@ -191,6 +193,7 @@ impl ProcessManager {
         let child = cmd
             .current_dir(&spec.working_dir)
             .kill_on_drop(true)
+            .stdin(Stdio::null())
             .stdout(stderr_file)
             .stderr(log_file)
             .spawn()
@@ -309,6 +312,7 @@ impl ProcessManager {
         let child = cmd
             .current_dir(&spec.working_dir)
             .kill_on_drop(true)
+            .stdin(Stdio::null())
             .stdout(stderr_file)
             .stderr(log_file)
             .spawn()

--- a/crates/coulson/src/process/procfile.rs
+++ b/crates/coulson/src/process/procfile.rs
@@ -38,29 +38,6 @@ fn read_procfile(dir: &Path) -> Option<String> {
     None
 }
 
-/// Get the user's login shell from `$SHELL`, falling back to `/bin/sh`.
-fn user_shell() -> PathBuf {
-    std::env::var("SHELL")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/bin/sh"))
-}
-
-/// Build login-shell arguments that source the interactive RC file before
-/// executing `cmd`.  Login shells (`-l`) only load profile files (.zprofile,
-/// .bash_profile), not .zshrc/.bashrc where mise/direnv are activated.
-fn login_shell_args(cmd: &str) -> (PathBuf, Vec<String>) {
-    let shell = user_shell();
-    let name = shell.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    let full_cmd = match name {
-        "zsh" => format!(". ~/.zshrc 2>/dev/null; {cmd}"),
-        "bash" => format!(". ~/.bashrc 2>/dev/null; {cmd}"),
-        _ => cmd.to_string(),
-    };
-    (shell, vec!["-l".to_string(), "-c".to_string(), full_cmd])
-}
-
 /// Check if parsed procfile content contains a `web` process type.
 fn has_web_process(content: &str) -> bool {
     procfile::parse(content)
@@ -114,10 +91,9 @@ impl ProcessProvider for ProcfileProvider {
                 let mut env = std::collections::HashMap::new();
                 env.insert("PORT".to_string(), port.to_string());
                 env.extend(app.env_overrides.clone());
-                let (command, args) = login_shell_args(cmd);
                 return Ok(ProcessSpec {
-                    command,
-                    args,
+                    command: PathBuf::new(),
+                    args: vec![cmd.to_string()],
                     env,
                     working_dir: root.clone(),
                     listen_target: ListenTarget::Tcp {
@@ -159,11 +135,9 @@ impl ProcessProvider for ProcfileProvider {
             "resolved Procfile web process"
         );
 
-        // 6. Use login shell with RC sourced for user env (direnv, mise, etc.)
-        let (command, args) = login_shell_args(&full_command);
         Ok(ProcessSpec {
-            command,
-            args,
+            command: PathBuf::new(),
+            args: vec![full_command],
             env,
             working_dir: root.clone(),
             listen_target: ListenTarget::Tcp {
@@ -257,10 +231,9 @@ mod tests {
             socket_dir: dir.clone(),
         };
         let spec = p.resolve(&app).unwrap();
-        assert_eq!(spec.command, user_shell());
-        assert_eq!(spec.args[0], "-l");
-        assert_eq!(spec.args[1], "-c");
-        assert!(spec.args[2].contains("bundle exec rails server -p $PORT"));
+
+        assert_eq!(spec.args.len(), 1);
+        assert!(spec.args[0].contains("bundle exec rails server -p $PORT"));
         assert!(spec.env.contains_key("PORT"));
         fs::remove_dir_all(&dir).ok();
     }
@@ -280,7 +253,8 @@ mod tests {
             socket_dir: dir.clone(),
         };
         let spec = p.resolve(&app).unwrap();
-        assert!(spec.args[2].contains("bin/dev"));
+
+        assert!(spec.args[0].contains("bin/dev"));
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -298,8 +272,8 @@ mod tests {
             socket_dir: dir.clone(),
         };
         let spec = p.resolve(&app).unwrap();
-        assert_eq!(spec.command, user_shell());
-        assert!(spec.args[2].contains("my-custom-server"));
+
+        assert!(spec.args[0].contains("my-custom-server"));
         fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/coulson/src/process/procfile.rs
+++ b/crates/coulson/src/process/procfile.rs
@@ -10,9 +10,9 @@ use super::provider::{
 /// Procfile provider — manages applications defined by a standard Procfile.
 ///
 /// Detection: directory contains `Procfile.dev` or `Procfile` with a `web:` process.
-/// Resolves to `$SHELL -l -c "<web command>"` with TCP port assignment via `$PORT`.
-/// Using the user's login shell ensures that environment managers (direnv, mise,
-/// rbenv, nvm, etc.) are properly loaded.
+/// Resolves to `$SHELL -l -c "<rc source>; <web command>"` with TCP port via `$PORT`.
+/// The RC file (.zshrc/.bashrc) is sourced explicitly because login shells don't
+/// load interactive config where tools like mise/direnv are typically activated.
 ///
 /// This provider is registered at the lowest priority so that ASGI and Node
 /// providers get first chance at detecting their respective app types.
@@ -45,6 +45,20 @@ fn user_shell() -> PathBuf {
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/bin/sh"))
+}
+
+/// Build login-shell arguments that source the interactive RC file before
+/// executing `cmd`.  Login shells (`-l`) only load profile files (.zprofile,
+/// .bash_profile), not .zshrc/.bashrc where mise/direnv are activated.
+fn login_shell_args(cmd: &str) -> (PathBuf, Vec<String>) {
+    let shell = user_shell();
+    let name = shell.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let full_cmd = match name {
+        "zsh" => format!(". ~/.zshrc 2>/dev/null; {cmd}"),
+        "bash" => format!(". ~/.bashrc 2>/dev/null; {cmd}"),
+        _ => cmd.to_string(),
+    };
+    (shell, vec!["-l".to_string(), "-c".to_string(), full_cmd])
 }
 
 /// Check if parsed procfile content contains a `web` process type.
@@ -93,16 +107,17 @@ impl ProcessProvider for ProcfileProvider {
     fn resolve(&self, app: &ManagedApp) -> anyhow::Result<ProcessSpec> {
         let root = &app.root;
 
-        // 1. coulson.json command override → $SHELL -l -c
+        // 1. coulson.json command override
         if let Some(manifest) = &app.manifest {
             if let Some(cmd) = manifest.get("command").and_then(|v| v.as_str()) {
                 let port = allocate_port()?;
                 let mut env = std::collections::HashMap::new();
                 env.insert("PORT".to_string(), port.to_string());
                 env.extend(app.env_overrides.clone());
+                let (command, args) = login_shell_args(cmd);
                 return Ok(ProcessSpec {
-                    command: user_shell(),
-                    args: vec!["-l".to_string(), "-c".to_string(), cmd.to_string()],
+                    command,
+                    args,
                     env,
                     working_dir: root.clone(),
                     listen_target: ListenTarget::Tcp {
@@ -144,10 +159,11 @@ impl ProcessProvider for ProcfileProvider {
             "resolved Procfile web process"
         );
 
-        // 6. Use $SHELL -l -c for shell features and user env (direnv, mise, etc.)
+        // 6. Use login shell with RC sourced for user env (direnv, mise, etc.)
+        let (command, args) = login_shell_args(&full_command);
         Ok(ProcessSpec {
-            command: user_shell(),
-            args: vec!["-l".to_string(), "-c".to_string(), full_command],
+            command,
+            args,
             env,
             working_dir: root.clone(),
             listen_target: ListenTarget::Tcp {
@@ -283,7 +299,7 @@ mod tests {
         };
         let spec = p.resolve(&app).unwrap();
         assert_eq!(spec.command, user_shell());
-        assert_eq!(spec.args[2], "my-custom-server");
+        assert!(spec.args[2].contains("my-custom-server"));
         fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
- Add tmux as an alternative process backend for managed apps (ASGI, Node.js, Procfile)
- New `COULSON_PROCESS_BACKEND` config: `auto` (default, uses tmux if available), `tmux`, `direct`
- `coulson attach <app>` command to attach to a managed process's tmux session
- `coulson doctor` checks tmux availability and reports backend status