### PR TITLE
feat: keychain-based tunnel login + remotely-managed tunnel with auto DNS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tower = { version = "0.5", features = ["util"] }
 percent-encoding = "2"
 procfile = "0.2"
 libc = "0.2"
+keyring = { version = "3", features = ["apple-native", "linux-native"] }
 
 [profile.release]
 lto = true

--- a/CoulsonApp/Sources/ViewModel/CoulsonViewModel.swift
+++ b/CoulsonApp/Sources/ViewModel/CoulsonViewModel.swift
@@ -2,6 +2,13 @@ import Foundation
 import Network
 import SwiftUI
 
+/// Directory name matching Rust's `DIR_NAME`: debug builds use "coulson-dev".
+#if DEBUG
+private let dirName = "coulson-dev"
+#else
+private let dirName = "coulson"
+#endif
+
 @MainActor
 final class CoulsonViewModel: ObservableObject {
     @Published var apps: [AppRecord] = []
@@ -30,21 +37,21 @@ final class CoulsonViewModel: ObservableObject {
         let base = ProcessInfo.processInfo.environment["XDG_RUNTIME_DIR"]
             ?? ProcessInfo.processInfo.environment["TMPDIR"]
             ?? "/tmp"
-        return (base as NSString).appendingPathComponent("coulson")
+        return (base as NSString).appendingPathComponent(dirName)
     }
 
     /// XDG-aware config directory fallback.
     static var defaultCertsDir: String {
         let base = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
             ?? (NSHomeDirectory() + "/.config")
-        return (base as NSString).appendingPathComponent("coulson/certs")
+        return (base as NSString).appendingPathComponent("\(dirName)/certs")
     }
 
     /// XDG-aware state directory fallback (matches Rust default for socket).
     static var defaultStateDir: String {
         let base = ProcessInfo.processInfo.environment["XDG_STATE_HOME"]
             ?? (NSHomeDirectory() + "/.local/state")
-        return (base as NSString).appendingPathComponent("coulson")
+        return (base as NSString).appendingPathComponent(dirName)
     }
 
     init() {

--- a/crates/coulson/Cargo.toml
+++ b/crates/coulson/Cargo.toml
@@ -53,6 +53,7 @@ tower.workspace = true
 percent-encoding.workspace = true
 procfile.workspace = true
 libc.workspace = true
+keyring.workspace = true
 
 [features]
 builtin-quick-tunnel = []

--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -428,6 +428,10 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
         }
         "app.delete" => {
             let params: AppIdParams = parse_params!(req);
+            // Stop managed process before deleting
+            let mut pm = state.process_manager.lock().await;
+            pm.kill_process(params.app_id).await;
+            drop(pm);
             service::app_delete(state, params.app_id)
                 .map(|_| json!({ "deleted": true }))
                 .map_err(ControlError::from)

--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -7,6 +7,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tracing::{debug, error, info};
 
+use crate::credentials;
 use crate::domain::TunnelMode;
 use crate::service;
 use crate::service::ServiceError;
@@ -72,8 +73,10 @@ struct AppIdParams {
 
 #[derive(Debug, Deserialize)]
 struct NamedTunnelSetupParams {
-    api_token: String,
-    account_id: String,
+    #[serde(default)]
+    api_token: Option<String>,
+    #[serde(default)]
+    account_id: Option<String>,
     domain: String,
     #[serde(default)]
     tunnel_name: Option<String>,
@@ -81,7 +84,8 @@ struct NamedTunnelSetupParams {
 
 #[derive(Debug, Deserialize)]
 struct NamedTunnelTeardownParams {
-    api_token: String,
+    #[serde(default)]
+    api_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -555,22 +559,96 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 );
             }
 
+            // Resolve api_token: param → keychain
+            let api_token = match params.api_token {
+                Some(ref t) if !t.trim().is_empty() => t.clone(),
+                _ => match credentials::get_api_token() {
+                    Ok(Some(t)) => t,
+                    Ok(None) => {
+                        return render_err(
+                            req.request_id,
+                            ControlError::InvalidParams(
+                                "api_token required (not found in keychain)".to_string(),
+                            ),
+                        );
+                    }
+                    Err(e) => return internal_error(req.request_id, e.to_string()),
+                },
+            };
+
+            // Resolve account_id: param → saved setting → CF API
+            let account_id = match params.account_id {
+                Some(ref a) if !a.trim().is_empty() => a.clone(),
+                _ => match state.store.get_setting("named_tunnel.account_id") {
+                    Ok(Some(a)) => a,
+                    Ok(None) => {
+                        // Auto-resolve from API token
+                        match tunnel::named::resolve_account_id(&api_token).await {
+                            Ok(id) => id,
+                            Err(e) => {
+                                return render_err(
+                                    req.request_id,
+                                    ControlError::InvalidParams(format!(
+                                        "account_id not found, auto-detect failed: {e}"
+                                    )),
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => return internal_error(req.request_id, e.to_string()),
+                },
+            };
+
             let tunnel_name = params
                 .tunnel_name
                 .unwrap_or_else(|| format!("coulson-{}", &params.domain));
 
-            let (credentials, tunnel_id) = match tunnel::named::create_named_tunnel(
-                &params.api_token,
-                &params.account_id,
-                &tunnel_name,
+            let (credentials, tunnel_id) =
+                match tunnel::named::create_named_tunnel(&api_token, &account_id, &tunnel_name)
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => return internal_error(req.request_id, e.to_string()),
+                };
+
+            // Create wildcard CNAME: *.domain -> tunnel_id.cfargotunnel.com
+            let cname_name = format!("*.{}", params.domain);
+            let zone_id = match tunnel::named::find_zone_id(&api_token, &params.domain).await {
+                Ok(id) => id,
+                Err(e) => {
+                    let _ = tunnel::named::delete_named_tunnel(&api_token, &account_id, &tunnel_id)
+                        .await;
+                    return internal_error(
+                        req.request_id,
+                        format!("failed to find zone for {}: {e}", params.domain),
+                    );
+                }
+            };
+            let dns_record_id = match tunnel::named::create_dns_cname(
+                &api_token,
+                &zone_id,
+                &cname_name,
+                &tunnel_id,
             )
             .await
             {
-                Ok(v) => v,
-                Err(e) => return internal_error(req.request_id, e.to_string()),
+                Ok(id) => id,
+                Err(e) => {
+                    let _ = tunnel::named::delete_named_tunnel(&api_token, &account_id, &tunnel_id)
+                        .await;
+                    return internal_error(
+                        req.request_id,
+                        format!("failed to create DNS CNAME: {e}"),
+                    );
+                }
             };
 
-            // Persist credentials and domain
+            // Save api_token to keychain on success
+            if let Err(e) = credentials::store_api_token(&api_token) {
+                tracing::warn!(error = %e, "failed to save api_token to keychain");
+            }
+
+            // Persist credentials, domain, account_id, zone_id, dns_record_id
             let creds_json = match serde_json::to_string(&credentials) {
                 Ok(v) => v,
                 Err(e) => return internal_error(req.request_id, e.to_string()),
@@ -589,7 +667,16 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
             }
             if let Err(e) = state
                 .store
-                .set_setting("named_tunnel.account_id", &params.account_id)
+                .set_setting("named_tunnel.account_id", &account_id)
+            {
+                return internal_error(req.request_id, e.to_string());
+            }
+            if let Err(e) = state.store.set_setting("named_tunnel.zone_id", &zone_id) {
+                return internal_error(req.request_id, e.to_string());
+            }
+            if let Err(e) = state
+                .store
+                .set_setting("named_tunnel.dns_record_id", &dns_record_id)
             {
                 return internal_error(req.request_id, e.to_string());
             }
@@ -619,11 +706,27 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 "tunnel_id": tunnel_id,
                 "cname_target": cname_target,
                 "domain": params.domain,
-                "hint": format!("Add DNS: *.{} CNAME {}", params.domain, cname_target),
             }))
         }
         "named_tunnel.teardown" => {
             let params: NamedTunnelTeardownParams = parse_params!(req);
+
+            // Resolve api_token: param → keychain
+            let api_token = match params.api_token {
+                Some(ref t) if !t.trim().is_empty() => t.clone(),
+                _ => match credentials::get_api_token() {
+                    Ok(Some(t)) => t,
+                    Ok(None) => {
+                        return render_err(
+                            req.request_id,
+                            ControlError::InvalidParams(
+                                "api_token required (not found in keychain)".to_string(),
+                            ),
+                        );
+                    }
+                    Err(e) => return internal_error(req.request_id, e.to_string()),
+                },
+            };
 
             // Disconnect if active (scope the lock to avoid holding across await)
             let active_handle = state.named_tunnel.lock().take();
@@ -642,7 +745,7 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 };
 
                 if let Err(e) = tunnel::named::delete_named_tunnel(
-                    &params.api_token,
+                    &api_token,
                     &account_id,
                     &handle.credentials.tunnel_id,
                 )
@@ -657,16 +760,25 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 if let (Ok(Some(creds_str)), Ok(Some(acct))) = (creds_json, account_id) {
                     if let Ok(creds) = serde_json::from_str::<tunnel::TunnelCredentials>(&creds_str)
                     {
-                        if let Err(e) = tunnel::named::delete_named_tunnel(
-                            &params.api_token,
-                            &acct,
-                            &creds.tunnel_id,
-                        )
-                        .await
+                        if let Err(e) =
+                            tunnel::named::delete_named_tunnel(&api_token, &acct, &creds.tunnel_id)
+                                .await
                         {
                             return internal_error(req.request_id, e.to_string());
                         }
                     }
+                }
+            }
+
+            // Delete DNS CNAME record (best-effort)
+            if let (Ok(Some(zone_id)), Ok(Some(record_id))) = (
+                state.store.get_setting("named_tunnel.zone_id"),
+                state.store.get_setting("named_tunnel.dns_record_id"),
+            ) {
+                if let Err(e) =
+                    tunnel::named::delete_dns_record(&api_token, &zone_id, &record_id).await
+                {
+                    tracing::warn!(error = %e, "failed to delete DNS CNAME during teardown");
                 }
             }
 
@@ -675,6 +787,8 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 "named_tunnel.credentials",
                 "named_tunnel.domain",
                 "named_tunnel.account_id",
+                "named_tunnel.zone_id",
+                "named_tunnel.dns_record_id",
             ] {
                 if let Err(e) = state.store.delete_setting(key) {
                     tracing::warn!(error = %e, key, "failed to delete setting during teardown");
@@ -848,7 +962,7 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                     ),
                 );
             }
-            if let Err(e) = state.store.set_setting("cf.api_token", &params.api_token) {
+            if let Err(e) = credentials::store_api_token(&params.api_token) {
                 return internal_error(req.request_id, e.to_string());
             }
             if let Err(e) = state.store.set_setting("cf.account_id", &params.account_id) {
@@ -857,7 +971,7 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
             Ok(json!({ "configured": true }))
         }
         "tunnel.configure_status" => {
-            let has_token = matches!(state.store.get_setting("cf.api_token"), Ok(Some(_)));
+            let has_token = matches!(credentials::get_api_token(), Ok(Some(_)));
             let has_account = matches!(state.store.get_setting("cf.account_id"), Ok(Some(_)));
             Ok(json!({ "configured": has_token && has_account }))
         }
@@ -910,9 +1024,19 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
         "tunnel.app_teardown" => {
             let params: AppIdParams = parse_params!(req);
 
-            // Read CF credentials
-            let api_token =
-                require_setting!(state, req, "cf.api_token", "CF credentials not configured");
+            // Read CF credentials (api_token from keychain)
+            let api_token = match credentials::get_api_token() {
+                Ok(Some(t)) => t,
+                Ok(None) => {
+                    return render_err(
+                        req.request_id,
+                        ControlError::InvalidParams(
+                            "CF credentials not configured (no api_token in keychain)".to_string(),
+                        ),
+                    );
+                }
+                Err(e) => return internal_error(req.request_id, e.to_string()),
+            };
             let account_id =
                 require_setting!(state, req, "cf.account_id", "cf.account_id not configured");
 

--- a/crates/coulson/src/credentials.rs
+++ b/crates/coulson/src/credentials.rs
@@ -1,0 +1,28 @@
+use keyring::Entry;
+
+const SERVICE: &str = "coulson";
+const CF_TOKEN_ACCOUNT: &str = "cf-api-token";
+
+pub fn store_api_token(token: &str) -> anyhow::Result<()> {
+    let entry = Entry::new(SERVICE, CF_TOKEN_ACCOUNT)?;
+    entry.set_password(token)?;
+    Ok(())
+}
+
+pub fn get_api_token() -> anyhow::Result<Option<String>> {
+    let entry = Entry::new(SERVICE, CF_TOKEN_ACCOUNT)?;
+    match entry.get_password() {
+        Ok(token) => Ok(Some(token)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn delete_api_token() -> anyhow::Result<()> {
+    let entry = Entry::new(SERVICE, CF_TOKEN_ACCOUNT)?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1,6 +1,7 @@
 mod certs;
 mod config;
 mod control;
+mod credentials;
 mod dashboard;
 mod domain;
 mod mdns;
@@ -296,19 +297,26 @@ enum TunnelCommands {
         /// Tunnel name (defaults to coulson-<domain>)
         #[arg(long)]
         tunnel_name: Option<String>,
-        /// CF API token
+        /// CF API token (saved to keychain after first use)
         #[arg(long)]
-        api_token: String,
-        /// CF account ID
+        api_token: Option<String>,
+        /// CF account ID (saved to DB after first use)
         #[arg(long)]
-        account_id: String,
+        account_id: Option<String>,
     },
     /// Delete the global named tunnel via CF API
     Teardown {
-        /// CF API token
+        /// CF API token (reads from keychain if omitted)
         #[arg(long)]
-        api_token: String,
+        api_token: Option<String>,
     },
+    /// Save a Cloudflare API token to keychain
+    Login {
+        /// API token (Account > Cloudflare Tunnel > Edit, Zone > DNS > Edit)
+        token: String,
+    },
+    /// Remove saved CF API token from keychain
+    Logout,
     /// Connect a per-app named tunnel using a Cloudflare tunnel token
     AppSetup {
         /// App name or domain
@@ -547,7 +555,17 @@ fn run_doctor(cfg: CoulsonConfig, check_pf: bool) -> anyhow::Result<()> {
         }
     }
 
-    // 6. Scan warnings
+    // 6. CF API token (keychain)
+    match credentials::get_api_token() {
+        Ok(Some(_)) => print_check(true, "CF API token saved in keychain"),
+        Ok(None) => print_check(true, "CF API token not set (OK if not using CF tunnels)"),
+        Err(e) => {
+            print_check(false, &format!("keychain access error: {e}"));
+            issues += 1;
+        }
+    }
+
+    // 7. Scan warnings
     match runtime::read_scan_warnings(&cfg.scan_warnings_path) {
         Ok(Some(data)) => {
             if data.scan.warning_count == 0 {
@@ -564,7 +582,7 @@ fn run_doctor(cfg: CoulsonConfig, check_pf: bool) -> anyhow::Result<()> {
         Err(_) => print_check(true, "no scan warnings file (OK if first run)"),
     }
 
-    // 7. LAN access (per-app)
+    // 8. LAN access (per-app)
     if cfg.listen_http.ip().is_unspecified() {
         print_check(
             true,
@@ -585,7 +603,7 @@ fn run_doctor(cfg: CoulsonConfig, check_pf: bool) -> anyhow::Result<()> {
         print_check(true, &format!("proxy on {}", cfg.listen_http));
     }
 
-    // 8. TLS certificates
+    // 9. TLS certificates
     if cfg.listen_https.is_some() {
         let ca_path = cfg.certs_dir.join("ca.crt");
         let cert_path = cfg.certs_dir.join("server.crt");
@@ -611,7 +629,7 @@ fn run_doctor(cfg: CoulsonConfig, check_pf: bool) -> anyhow::Result<()> {
         print_check(true, "HTTPS listener disabled (no TLS check needed)");
     }
 
-    // 9. pf port forwarding (optional)
+    // 10. pf port forwarding (optional)
     if check_pf {
         #[cfg(target_os = "macos")]
         {
@@ -2014,6 +2032,28 @@ fn run_unshare(cfg: CoulsonConfig, name: String) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn run_tunnel_login(token: &str) -> anyhow::Result<()> {
+    let handle = tokio::runtime::Handle::current();
+    let body: serde_json::Value = tokio::task::block_in_place(|| {
+        handle.block_on(async {
+            let client = reqwest::Client::new();
+            let resp = client
+                .get("https://api.cloudflare.com/client/v4/user/tokens/verify")
+                .header("Authorization", format!("Bearer {token}"))
+                .send()
+                .await?;
+            resp.json().await.map_err(anyhow::Error::from)
+        })
+    })?;
+    if body.get("success").and_then(|v| v.as_bool()) != Some(true) {
+        bail!("token verification failed: {body}");
+    }
+
+    credentials::store_api_token(token)?;
+    println!("{} API token verified and saved to keychain", "✓".green());
+    Ok(())
+}
+
 fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> {
     let client = RpcClient::new(&cfg.control_socket);
 
@@ -2285,7 +2325,16 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
                     println!("  domain: {}", domain.cyan());
                 }
                 TunnelMode::Global => {
-                    println!("  {}", "app exposed via global named tunnel".dimmed());
+                    let domain = client
+                        .call("named_tunnel.status", serde_json::json!({}))
+                        .ok()
+                        .and_then(|v| {
+                            let d = v.get("domain")?.as_str()?;
+                            Some(format!("{bare_name}.{d}"))
+                        });
+                    if let Some(d) = domain {
+                        println!("  {}", format!("http://{d}").cyan());
+                    }
                 }
                 TunnelMode::None => {}
             }
@@ -2326,15 +2375,27 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
             api_token,
             account_id,
         } => {
+            let token = match api_token {
+                Some(t) => t,
+                None => credentials::get_api_token()?
+                    .ok_or_else(|| anyhow::anyhow!("no saved API token, pass --api-token"))?,
+            };
+
             let mut params = serde_json::json!({
-                "api_token": api_token,
-                "account_id": account_id,
+                "api_token": token,
                 "domain": domain,
             });
+            if let Some(a) = &account_id {
+                params["account_id"] = serde_json::json!(a);
+            }
             if let Some(n) = &tunnel_name {
                 params["tunnel_name"] = serde_json::json!(n);
             }
             let result = client.call("named_tunnel.setup", params)?;
+
+            // Save token to keychain on success
+            credentials::store_api_token(&token)?;
+
             let tunnel_id = result
                 .get("tunnel_id")
                 .and_then(|v| v.as_str())
@@ -2350,11 +2411,25 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
             Ok(())
         }
         TunnelCommands::Teardown { api_token } => {
+            let token = match api_token {
+                Some(t) => t,
+                None => credentials::get_api_token()?
+                    .ok_or_else(|| anyhow::anyhow!("no saved API token, pass --api-token"))?,
+            };
             client.call(
                 "named_tunnel.teardown",
-                serde_json::json!({ "api_token": api_token }),
+                serde_json::json!({ "api_token": token }),
             )?;
             println!("{} global named tunnel destroyed", "✓".green());
+            Ok(())
+        }
+        TunnelCommands::Login { token } => {
+            run_tunnel_login(&token)?;
+            Ok(())
+        }
+        TunnelCommands::Logout => {
+            credentials::delete_api_token()?;
+            println!("{} CF API token removed from keychain", "✓".green());
             Ok(())
         }
         TunnelCommands::AppSetup {

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -178,7 +178,7 @@ struct Cli {
 enum Commands {
     /// Start the daemon (proxy + control + scanner)
     Serve,
-    /// One-shot scan of apps_root
+    /// One-shot scan of apps directory
     Scan,
     /// List registered apps
     Ls {

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -288,15 +288,6 @@ enum TunnelCommands {
     },
     /// Disconnect global named tunnel
     Disconnect,
-    /// Save Cloudflare API credentials
-    Configure {
-        /// CF API token
-        #[arg(long)]
-        api_token: String,
-        /// CF account ID
-        #[arg(long)]
-        account_id: String,
-    },
     /// Create a global named tunnel via CF API
     Setup {
         /// Tunnel domain
@@ -2327,17 +2318,6 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
         TunnelCommands::Disconnect => {
             client.call("named_tunnel.disconnect", serde_json::json!({}))?;
             println!("{} named tunnel disconnected", "✓".green());
-            Ok(())
-        }
-        TunnelCommands::Configure {
-            api_token,
-            account_id,
-        } => {
-            client.call(
-                "tunnel.configure",
-                serde_json::json!({ "api_token": api_token, "account_id": account_id }),
-            )?;
-            println!("{} CF credentials saved", "✓".green());
             Ok(())
         }
         TunnelCommands::Setup {

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -280,7 +280,7 @@ enum TunnelCommands {
     },
     /// Connect global named tunnel
     Connect {
-        /// Tunnel token (from CF dashboard)
+        /// Tunnel token (from Cloudflare dashboard)
         #[arg(long)]
         token: Option<String>,
         /// Tunnel domain
@@ -289,7 +289,7 @@ enum TunnelCommands {
     },
     /// Disconnect global named tunnel
     Disconnect,
-    /// Create a global named tunnel via CF API
+    /// Create a global named tunnel via Cloudflare API
     Setup {
         /// Tunnel domain
         #[arg(long)]
@@ -297,16 +297,16 @@ enum TunnelCommands {
         /// Tunnel name (defaults to coulson-<domain>)
         #[arg(long)]
         tunnel_name: Option<String>,
-        /// CF API token (saved to keychain after first use)
+        /// Cloudflare API token (saved to keychain after first use)
         #[arg(long)]
         api_token: Option<String>,
-        /// CF account ID (saved to DB after first use)
+        /// Cloudflare account ID (saved to DB after first use)
         #[arg(long)]
         account_id: Option<String>,
     },
-    /// Delete the global named tunnel via CF API
+    /// Delete the global named tunnel via Cloudflare API
     Teardown {
-        /// CF API token (reads from keychain if omitted)
+        /// Cloudflare API token (reads from keychain if omitted)
         #[arg(long)]
         api_token: Option<String>,
     },
@@ -2252,15 +2252,11 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
 
             // CF credentials status
             println!();
-            let cf_status = client.call("tunnel.configure_status", serde_json::json!({}));
-            let cf_configured = cf_status
-                .ok()
-                .and_then(|v| v.get("configured").and_then(|c| c.as_bool()))
-                .unwrap_or(false);
-            if cf_configured {
-                println!("CF Credentials: {}", "configured".green());
+            let has_token = credentials::get_api_token().ok().flatten().is_some();
+            if has_token {
+                println!("CF API Token: {}", "saved in keychain".green());
             } else {
-                println!("CF Credentials: {}", "not configured".dimmed());
+                println!("CF API Token: {}", "not configured".dimmed());
             }
 
             Ok(())

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -17,6 +17,8 @@ use anyhow::Context;
 use tokio::process::{Child, Command};
 use tracing::{info, warn};
 
+use std::process::Stdio;
+
 use provider::{ManagedApp, ProcessSpec};
 
 pub type ProcessManagerHandle = Arc<tokio::sync::Mutex<ProcessManager>>;
@@ -191,6 +193,7 @@ impl ProcessManager {
         let child = cmd
             .current_dir(&spec.working_dir)
             .kill_on_drop(true)
+            .stdin(Stdio::null())
             .stdout(stderr_file)
             .stderr(log_file)
             .spawn()
@@ -309,6 +312,7 @@ impl ProcessManager {
         let child = cmd
             .current_dir(&spec.working_dir)
             .kill_on_drop(true)
+            .stdin(Stdio::null())
             .stdout(stderr_file)
             .stderr(log_file)
             .spawn()

--- a/crates/coulson/src/process/procfile.rs
+++ b/crates/coulson/src/process/procfile.rs
@@ -10,9 +10,9 @@ use super::provider::{
 /// Procfile provider — manages applications defined by a standard Procfile.
 ///
 /// Detection: directory contains `Procfile.dev` or `Procfile` with a `web:` process.
-/// Resolves to `$SHELL -l -c "<web command>"` with TCP port assignment via `$PORT`.
-/// Using the user's login shell ensures that environment managers (direnv, mise,
-/// rbenv, nvm, etc.) are properly loaded.
+/// Resolves to `$SHELL -l -c "<rc source>; <web command>"` with TCP port via `$PORT`.
+/// The RC file (.zshrc/.bashrc) is sourced explicitly because login shells don't
+/// load interactive config where tools like mise/direnv are typically activated.
 ///
 /// This provider is registered at the lowest priority so that ASGI and Node
 /// providers get first chance at detecting their respective app types.
@@ -45,6 +45,20 @@ fn user_shell() -> PathBuf {
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/bin/sh"))
+}
+
+/// Build login-shell arguments that source the interactive RC file before
+/// executing `cmd`.  Login shells (`-l`) only load profile files (.zprofile,
+/// .bash_profile), not .zshrc/.bashrc where mise/direnv are activated.
+fn login_shell_args(cmd: &str) -> (PathBuf, Vec<String>) {
+    let shell = user_shell();
+    let name = shell.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let full_cmd = match name {
+        "zsh" => format!(". ~/.zshrc 2>/dev/null; {cmd}"),
+        "bash" => format!(". ~/.bashrc 2>/dev/null; {cmd}"),
+        _ => cmd.to_string(),
+    };
+    (shell, vec!["-l".to_string(), "-c".to_string(), full_cmd])
 }
 
 /// Check if parsed procfile content contains a `web` process type.
@@ -93,16 +107,17 @@ impl ProcessProvider for ProcfileProvider {
     fn resolve(&self, app: &ManagedApp) -> anyhow::Result<ProcessSpec> {
         let root = &app.root;
 
-        // 1. coulson.json command override → $SHELL -l -c
+        // 1. coulson.json command override
         if let Some(manifest) = &app.manifest {
             if let Some(cmd) = manifest.get("command").and_then(|v| v.as_str()) {
                 let port = allocate_port()?;
                 let mut env = std::collections::HashMap::new();
                 env.insert("PORT".to_string(), port.to_string());
                 env.extend(app.env_overrides.clone());
+                let (command, args) = login_shell_args(cmd);
                 return Ok(ProcessSpec {
-                    command: user_shell(),
-                    args: vec!["-l".to_string(), "-c".to_string(), cmd.to_string()],
+                    command,
+                    args,
                     env,
                     working_dir: root.clone(),
                     listen_target: ListenTarget::Tcp {
@@ -144,10 +159,11 @@ impl ProcessProvider for ProcfileProvider {
             "resolved Procfile web process"
         );
 
-        // 6. Use $SHELL -l -c for shell features and user env (direnv, mise, etc.)
+        // 6. Use login shell with RC sourced for user env (direnv, mise, etc.)
+        let (command, args) = login_shell_args(&full_command);
         Ok(ProcessSpec {
-            command: user_shell(),
-            args: vec!["-l".to_string(), "-c".to_string(), full_command],
+            command,
+            args,
             env,
             working_dir: root.clone(),
             listen_target: ListenTarget::Tcp {
@@ -283,7 +299,7 @@ mod tests {
         };
         let spec = p.resolve(&app).unwrap();
         assert_eq!(spec.command, user_shell());
-        assert_eq!(spec.args[2], "my-custom-server");
+        assert!(spec.args[2].contains("my-custom-server"));
         fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/coulson/src/service.rs
+++ b/crates/coulson/src/service.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use crate::credentials;
 use crate::domain::{AppSpec, DomainName, TunnelMode};
 use crate::runtime;
 use crate::runtime::ScanWarningsFile;
@@ -481,10 +482,8 @@ pub async fn app_set_tunnel_mode(
             .and_then(|c| serde_json::from_str::<tunnel::TunnelCredentials>(c).ok())
             .is_some();
         let has_cf_config = {
-            let token = state
-                .store
-                .get_setting("cf.api_token")
-                .map_err(|e| ServiceError::Internal(e.to_string()))?;
+            let token =
+                credentials::get_api_token().map_err(|e| ServiceError::Internal(e.to_string()))?;
             let account = state
                 .store
                 .get_setting("cf.account_id")
@@ -658,23 +657,28 @@ pub async fn app_set_tunnel_mode(
                     }
                 }
 
-                // API-based: create tunnel via CF API
-                let api_token = state
-                    .store
-                    .get_setting("cf.api_token")
+                // API-based: create tunnel via CF API (token from keychain)
+                let api_token = credentials::get_api_token()
                     .map_err(|e| ServiceError::Internal(e.to_string()))?
                     .ok_or_else(|| {
                         ServiceError::InvalidParams(
                             "CF credentials not configured, run tunnel.configure first".to_string(),
                         )
                     })?;
-                let account_id = state
+                let account_id = match state
                     .store
                     .get_setting("cf.account_id")
                     .map_err(|e| ServiceError::Internal(e.to_string()))?
-                    .ok_or_else(|| {
-                        ServiceError::InvalidParams("cf.account_id not configured".to_string())
-                    })?;
+                {
+                    Some(id) => id,
+                    None => tunnel::named::resolve_account_id(&api_token)
+                        .await
+                        .map_err(|e| {
+                            ServiceError::InvalidParams(format!(
+                                "cf.account_id not configured, auto-detect failed: {e}"
+                            ))
+                        })?,
+                };
 
                 let tunnel_name = format!("coulson-{app_id}");
                 let (credentials, tunnel_id) =

--- a/crates/coulson/src/tunnel/named.rs
+++ b/crates/coulson/src/tunnel/named.rs
@@ -35,6 +35,45 @@ fn cf_error_message(errors: &[CfApiError]) -> String {
         .join("; ")
 }
 
+/// Resolve the account ID from a CF API token.
+/// Calls `GET /accounts` and returns the first account's ID.
+pub async fn resolve_account_id(api_token: &str) -> anyhow::Result<String> {
+    #[derive(Debug, Deserialize)]
+    struct Account {
+        id: String,
+    }
+
+    let client = reqwest::Client::new();
+    let url = format!("{CF_API_BASE}/accounts?per_page=1");
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {api_token}"))
+        .send()
+        .await
+        .context("failed to contact Cloudflare accounts API")?;
+
+    let body: CfApiResponse<Vec<Account>> = resp
+        .json()
+        .await
+        .context("failed to parse CF accounts response")?;
+
+    if !body.success {
+        let msg = if body.errors.is_empty() {
+            "unknown error".to_string()
+        } else {
+            cf_error_message(&body.errors)
+        };
+        anyhow::bail!("failed to list accounts: {msg}");
+    }
+
+    let accounts = body.result.unwrap_or_default();
+    let account = accounts
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no accounts found for this API token"))?;
+    Ok(account.id)
+}
+
 /// Create a named Cloudflare Tunnel via the CF API.
 /// Returns (credentials, tunnel_id).
 pub async fn create_named_tunnel(
@@ -56,6 +95,7 @@ pub async fn create_named_tunnel(
         .json(&serde_json::json!({
             "name": name,
             "tunnel_secret": secret_b64,
+            "config_src": "cloudflare",
         }))
         .send()
         .await


### PR DESCRIPTION
- Simplify `tunnel login` to accept API token as CLI argument, verify via CF API, store in system keychain
- Create remotely-managed tunnels (`config_src: "cloudflare"`) visible in Zero Trust dashboard
- Auto-create wildcard CNAME DNS record during `tunnel setup`, auto-delete during `teardown`
- Fix `tunnel status` credential check to use keychain
- Add `credentials.rs` keychain storage module, remove `sha2` dependency