### PR TITLE
feat(inspector): embedded /_coulson/ inspector with loopback-pinned replay

### DIFF
--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -82,6 +82,8 @@ pub struct CoulsonConfig {
     pub runtime_dir: PathBuf,
     pub process_backend: ProcessBackend,
     pub hook_timeout_secs: u64,
+    pub inspector_username: Option<String>,
+    pub inspector_password: Option<String>,
 }
 
 impl Default for CoulsonConfig {
@@ -120,6 +122,8 @@ impl Default for CoulsonConfig {
             runtime_dir,
             process_backend: ProcessBackend::Auto,
             hook_timeout_secs: 60,
+            inspector_username: None,
+            inspector_password: None,
         }
     }
 }
@@ -173,6 +177,14 @@ impl CoulsonConfig {
         }
         if let Some(v) = file.hook_timeout_secs {
             cfg.hook_timeout_secs = v;
+        }
+        if let Some(ref insp) = file.inspector {
+            if let Some(ref v) = insp.username {
+                cfg.inspector_username = Some(v.clone());
+            }
+            if let Some(ref v) = insp.password {
+                cfg.inspector_password = Some(v.clone());
+            }
         }
 
         // Layer 3: Environment variables (highest priority)
@@ -229,6 +241,12 @@ impl CoulsonConfig {
             cfg.hook_timeout_secs = raw
                 .parse()
                 .with_context(|| format!("invalid COULSON_HOOK_TIMEOUT_SECS: {raw}"))?;
+        }
+        if let Ok(v) = env::var("COULSON_INSPECTOR_USERNAME") {
+            cfg.inspector_username = Some(v);
+        }
+        if let Ok(v) = env::var("COULSON_INSPECTOR_PASSWORD") {
+            cfg.inspector_password = Some(v);
         }
         if let Ok(raw) = env::var("COULSON_PROCESS_BACKEND") {
             cfg.process_backend = parse_process_backend(&raw)
@@ -331,6 +349,13 @@ struct ConfigFile {
     runtime_dir: Option<String>,
     process_backend: Option<String>,
     hook_timeout_secs: Option<u64>,
+    inspector: Option<InspectorConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct InspectorConfig {
+    username: Option<String>,
+    password: Option<String>,
 }
 
 impl ConfigFile {
@@ -386,7 +411,8 @@ impl ConfigFile {
             certs_dir,
             runtime_dir,
             process_backend,
-            hook_timeout_secs
+            hook_timeout_secs,
+            inspector
         );
     }
 }

--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -377,12 +377,8 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                 Ok(_) => return render_err(req.request_id, ControlError::NotFound),
                 Err(e) => return internal_error(req.request_id, e.to_string()),
             }
-            match crate::dashboard::execute_replay(
-                &state.store,
-                &params.app_name,
-                &params.request_id,
-            )
-            .await
+            match crate::dashboard::execute_replay(state, &params.app_name, &params.request_id)
+                .await
             {
                 Ok(outcome) => {
                     if let Some(ref err) = outcome.error {

--- a/crates/coulson/src/dashboard/handlers.rs
+++ b/crates/coulson/src/dashboard/handlers.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use axum::extract::{Form, Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use serde::Deserialize;
@@ -14,6 +14,19 @@ use super::DashboardState;
 use crate::domain::TunnelMode;
 use crate::service;
 use crate::SharedState;
+
+const EMBEDDED_HEADER: &str = "x-coulson-embedded";
+const EMBEDDED_BASE: &str = "/_coulson";
+
+/// Detect embedded inspector mode from the `x-coulson-embedded` header.
+/// Returns `(is_embedded, base_path)` for URL generation in templates.
+fn embedded_base(headers: &HeaderMap, app_name: &str) -> (bool, String) {
+    if headers.contains_key(EMBEDDED_HEADER) {
+        (true, EMBEDDED_BASE.to_string())
+    } else {
+        (false, format!("/apps/{app_name}"))
+    }
+}
 
 pub async fn favicon() -> impl IntoResponse {
     (
@@ -94,12 +107,14 @@ pub async fn page_app_detail(
 
 pub async fn page_requests(
     State(state): State<DashboardState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Response {
     let app = match state.shared.store.get_by_name(&id) {
         Ok(Some(app)) => app,
         _ => return html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared)),
     };
+    let (embedded, base_path) = embedded_base(&headers, &id);
     let port = state.shared.listen_http.port();
     let app_view = AppView::from_spec(&app, port, state.shared.use_default_http_port());
     let requests = state
@@ -115,12 +130,15 @@ pub async fn page_requests(
         ctx.insert("app", &app_view);
         ctx.insert("requests", &request_views);
         ctx.insert("request_count", &request_count);
+        ctx.insert("embedded", &embedded);
+        ctx.insert("base_path", &base_path);
     });
     Html(page).into_response()
 }
 
 pub async fn page_request_detail(
     State(state): State<DashboardState>,
+    headers: HeaderMap,
     Path((app_id, req_id)): Path<(String, String)>,
 ) -> Response {
     let app = match state.shared.store.get_by_name(&app_id) {
@@ -131,6 +149,7 @@ pub async fn page_request_detail(
         Ok(Some(r)) if r.app_id == app.id.0 => r,
         _ => return html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared)),
     };
+    let (embedded, base_path) = embedded_base(&headers, &app_id);
     let port = state.shared.listen_http.port();
     let app_view = AppView::from_spec(&app, port, state.shared.use_default_http_port());
     let req_view = RequestView::from_captured(&captured);
@@ -142,6 +161,8 @@ pub async fn page_request_detail(
         );
         ctx.insert("app", &app_view);
         ctx.insert("req", &req_view);
+        ctx.insert("embedded", &embedded);
+        ctx.insert("base_path", &base_path);
     });
     Html(page).into_response()
 }
@@ -562,6 +583,7 @@ pub async fn page_process_log(
 
 pub async fn action_toggle_inspect(
     State(state): State<DashboardState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Redirect {
     if let Ok(Some(app)) = state.shared.store.get_by_name(&id) {
@@ -571,21 +593,25 @@ pub async fn action_toggle_inspect(
             .set_inspect_enabled(app.id.0, !app.inspect_enabled);
         let _ = state.shared.reload_routes();
     }
-    Redirect::to(&format!("/apps/{id}/requests"))
+    let (_, base) = embedded_base(&headers, &id);
+    Redirect::to(&format!("{base}/requests"))
 }
 
 pub async fn action_clear_requests(
     State(state): State<DashboardState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Redirect {
     if let Ok(Some(app)) = state.shared.store.get_by_name(&id) {
         let _ = state.shared.store.delete_request_logs_for_app(app.id.0);
     }
-    Redirect::to(&format!("/apps/{id}/requests"))
+    let (_, base) = embedded_base(&headers, &id);
+    Redirect::to(&format!("{base}/requests"))
 }
 
 pub async fn action_replay(
     State(state): State<DashboardState>,
+    headers: HeaderMap,
     Path((app_id, req_id)): Path<(String, String)>,
 ) -> Response {
     let app = match state.shared.store.get_by_name(&app_id) {
@@ -597,9 +623,7 @@ pub async fn action_replay(
         _ => return html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared)),
     };
 
-    let outcome = execute_replay(&state.shared.store, &app_id, &req_id)
-        .await
-        .ok();
+    let outcome = execute_replay(&state.shared, &app_id, &req_id).await.ok();
 
     let port = state.shared.listen_http.port();
     let app_view = AppView::from_spec(&app, port, state.shared.use_default_http_port());
@@ -626,6 +650,7 @@ pub async fn action_replay(
         },
     };
 
+    let (embedded, base_path) = embedded_base(&headers, &app_id);
     let page = render_page("pages/request_detail.html", &state.shared, |ctx| {
         ctx.insert(
             "title",
@@ -634,6 +659,8 @@ pub async fn action_replay(
         ctx.insert("app", &app_view);
         ctx.insert("req", &req_view);
         ctx.insert("replay", &replay_view);
+        ctx.insert("embedded", &embedded);
+        ctx.insert("base_path", &base_path);
     });
     Html(page).into_response()
 }

--- a/crates/coulson/src/dashboard/render.rs
+++ b/crates/coulson/src/dashboard/render.rs
@@ -397,33 +397,46 @@ fn unsupported_replay(msg: &str) -> ReplayOutcome {
 }
 
 pub async fn execute_replay(
-    store: &crate::store::AppRepository,
+    state: &SharedState,
     app_name: &str,
     request_id: &str,
 ) -> anyhow::Result<ReplayOutcome> {
-    let app = store
+    let app = state
+        .store
         .get_by_name(app_name)?
         .ok_or_else(|| anyhow::anyhow!("app not found"))?;
-    let captured = store
+    let captured = state
+        .store
         .get_request_log(request_id)?
         .ok_or_else(|| anyhow::anyhow!("request not found"))?;
     if captured.app_id != app.id.0 {
         anyhow::bail!("request does not belong to app");
     }
 
-    let base_url = match &app.target {
-        BackendTarget::Tcp { host, port } => format!("http://{host}:{port}"),
-        BackendTarget::UnixSocket { .. } => {
-            return Ok(unsupported_replay(
-                "Replay not supported for Unix socket targets",
-            ));
-        }
-        _ => {
-            return Ok(unsupported_replay(
-                "Replay not supported for this target type",
-            ));
-        }
+    // StaticDir targets have no upstream to replay against — the proxy serves
+    // them directly and there's nothing meaningful to compare.
+    if matches!(&app.target, BackendTarget::StaticDir { .. }) {
+        return Ok(unsupported_replay(
+            "Replay not supported for static directory targets",
+        ));
+    }
+
+    // Replay through the local proxy so that all target kinds (TCP, Unix
+    // socket, Managed) are handled by the existing resolution pipeline. The
+    // `x-coulson-replay` header pins the replay to the captured `app_id`
+    // and makes the proxy skip `mw_auth`/`mw_force_https` (trusted because
+    // the header is only honored for loopback clients). Inspector capture
+    // still runs — the replayed request shows up in the log just like any
+    // other, which is explicitly what we want so users can compare.
+    let port = state.listen_http.port();
+    let connect_authority = if state.listen_http.ip().is_unspecified() {
+        format!("127.0.0.1:{port}")
+    } else {
+        // Use SocketAddr's Display which brackets IPv6 addresses for URLs.
+        state.listen_http.to_string()
     };
+    let host_header = extract_host_header(&captured.request_headers)
+        .unwrap_or_else(|| derive_host_from_domain(app.domain.0.as_str()));
 
     let path = &captured.path;
     let query = captured
@@ -431,10 +444,11 @@ pub async fn execute_replay(
         .as_ref()
         .map(|q| format!("?{q}"))
         .unwrap_or_default();
-    let url = format!("{base_url}{path}{query}");
+    let url = format!("http://{connect_authority}{path}{query}");
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap_or_default();
     let method: reqwest::Method = captured.method.parse().unwrap_or(reqwest::Method::GET);
@@ -449,6 +463,10 @@ pub async fn execute_replay(
         }
         req_builder = req_builder.header(k.as_str(), v.as_str());
     }
+    req_builder = req_builder.header("host", host_header);
+    // Pin replay to the captured app id so the proxy bypasses host routing
+    // and cannot be misrouted by default_app/CNAME/domain drift.
+    req_builder = req_builder.header(crate::proxy::REPLAY_HEADER, app.id.0.to_string());
     if let Some(ref body) = captured.request_body {
         req_builder = req_builder.body(body.clone());
     }
@@ -484,6 +502,25 @@ pub async fn execute_replay(
             body: None,
             error: Some(format!("Replay failed: {e}")),
         }),
+    }
+}
+
+/// Pull the original Host header out of the captured request headers JSON.
+fn extract_host_header(headers_json: &str) -> Option<String> {
+    let map: std::collections::HashMap<String, String> = serde_json::from_str(headers_json).ok()?;
+    map.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("host"))
+        .map(|(_, v)| v.clone())
+}
+
+/// Turn a stored domain (possibly a wildcard like `*.foo.coulson.local`) into
+/// a valid Host header. The captured request is preferred over this, but some
+/// older logs may not have recorded a Host header.
+fn derive_host_from_domain(domain: &str) -> String {
+    if let Some(rest) = domain.strip_prefix("*.") {
+        format!("wildcard.{rest}")
+    } else {
+        domain.to_string()
     }
 }
 

--- a/crates/coulson/src/dashboard/templates/base.html
+++ b/crates/coulson/src/dashboard/templates/base.html
@@ -42,6 +42,17 @@ Stimulus.register("modal", class extends Controller {
 <body class="bg-zinc-50 text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-50">
 <div class="flex flex-col min-h-screen">
 <div id="toast-container" class="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-sm"></div>
+{% if embedded %}
+<header class="sticky top-0 z-40 border-b border-zinc-200 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:border-zinc-800 dark:bg-zinc-950/80">
+  <div class="mx-auto max-w-6xl flex items-center justify-between px-6 h-14">
+    <span class="font-semibold text-base tracking-tight flex items-center gap-2">
+      <svg class="h-5 w-5 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/></svg>
+      Inspector — {{ app.name }}
+    </span>
+    <span class="text-xs text-zinc-400 dark:text-zinc-500 font-mono">{{ app.domain }}</span>
+  </div>
+</header>
+{% else %}
 <header class="sticky top-0 z-40 border-b border-zinc-200 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:border-zinc-800 dark:bg-zinc-950/80">
   <div class="mx-auto max-w-6xl flex items-center justify-between px-6 h-14">
     <div class="flex items-center gap-6">
@@ -66,10 +77,11 @@ Stimulus.register("modal", class extends Controller {
     </div>
   </div>
 </header>
+{% endif %}
 <main class="flex-1 mx-auto max-w-6xl w-full px-6 py-8">
 {% block content %}{% endblock content %}
 </main>
-<footer class="border-t border-zinc-200 dark:border-zinc-800 mt-auto">
+{% if not embedded %}<footer class="border-t border-zinc-200 dark:border-zinc-800 mt-auto">
   <div class="mx-auto max-w-6xl px-6 py-5 flex items-center justify-between">
     <div class="flex items-center gap-2">
       <svg class="h-4 w-4 text-zinc-400 dark:text-zinc-500" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="ft-c" x1="20%" y1="0%" x2="80%" y2="100%"><stop offset="0%" stop-color="currentColor" stop-opacity=".6"/><stop offset="100%" stop-color="currentColor" stop-opacity=".3"/></linearGradient></defs><rect x="100" y="100" width="824" height="824" rx="186" ry="186" fill="none" stroke="currentColor" stroke-width="60" opacity=".25"/><g transform="translate(512,512) scale(3.7)"><path d="M50-30A60 60 0 1 0 50 30L25 15A30 30 0 1 1 25-15Z" fill="url(#ft-c)"/></g></svg>
@@ -115,7 +127,7 @@ Stimulus.register("modal", class extends Controller {
       </a>
     </div>
   </div>
-</footer>
+</footer>{% endif %}
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/crates/coulson/src/dashboard/templates/pages/app_detail.html
+++ b/crates/coulson/src/dashboard/templates/pages/app_detail.html
@@ -35,10 +35,13 @@
     {% include "partials/settings_modal.html" %}
   </dialog>
 </div>
+<div id="detail-stream-config" class="hidden" data-stream-url="/apps/{{ app.name }}/stream"></div>
 <script>
 (function() {
-  var appName = '{{ app.name }}';
-  var evtSource = new EventSource('/apps/' + appName + '/stream');
+  var cfg = document.getElementById('detail-stream-config');
+  var streamUrl = cfg ? cfg.dataset.streamUrl : null;
+  if (!streamUrl) return;
+  var evtSource = new EventSource(streamUrl);
   evtSource.onmessage = function(event) {
     var ids = event.data.split(',');
     ids.forEach(function(id) {

--- a/crates/coulson/src/dashboard/templates/pages/request_detail.html
+++ b/crates/coulson/src/dashboard/templates/pages/request_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
-<a href="/apps/{{ app.name }}/requests" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-6 transition-colors"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5"/></svg>Back to Requests</a>
+{% set base = base_path | default(value="/apps/" ~ app.name) %}
+<a href="{{ base }}/requests" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-6 transition-colors"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5"/></svg>Back to Requests</a>
 
 <div class="flex items-start justify-between mb-8">
   <div>
@@ -14,7 +15,7 @@
       {% if req.response_time_ms %}&mdash; {{ req.response_time_ms }}ms{% endif %}
     </p>
   </div>
-  <form method="post" action="/apps/{{ app.name }}/requests/{{ req.id }}/replay">
+  <form method="post" action="{{ base }}/requests/{{ req.id }}/replay" data-turbo-frame="replay-result">
     <button type="submit" class="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-blue-700 transition-colors">
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182M2.985 19.644l3.181-3.182"/></svg>
       Replay
@@ -75,6 +76,7 @@
 {% endif %}
   </div>
 
+<turbo-frame id="replay-result">
 {% if replay %}
   <!-- Replay comparison -->
   <div class="rounded-xl border border-blue-200 bg-white shadow-sm dark:border-blue-900/50 dark:bg-zinc-900">
@@ -95,5 +97,6 @@
     </div>
   </div>
 {% endif %}
+</turbo-frame>
 </div>
 {% endblock content %}

--- a/crates/coulson/src/dashboard/templates/pages/requests.html
+++ b/crates/coulson/src/dashboard/templates/pages/requests.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
+{% set base = base_path | default(value="/apps/" ~ app.name) %}
+{% if not embedded %}
 <a href="/apps/{{ app.name }}" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-6 transition-colors"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5"/></svg>Back to {{ app.name }}</a>
+{% endif %}
 
 <div class="flex items-start justify-between mb-8">
   <div>
@@ -8,7 +11,7 @@
     <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{{ app.name }} &mdash; <span class="font-mono">{{ app.domain }}</span> &mdash; <span id="request-count">{{ request_count }}</span> requests</p>
   </div>
   <div class="flex items-center gap-3">
-    <form method="post" action="/apps/{{ app.name }}/toggle-inspect">
+    <form method="post" action="{{ base }}/toggle-inspect">
       <button type="submit" class="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium shadow-sm transition-colors {% if app.inspect_enabled %}bg-red-50 text-red-700 hover:bg-red-100 ring-1 ring-inset ring-red-600/20 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50{% else %}bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-400 dark:text-zinc-900{% endif %}">
         {% if app.inspect_enabled %}
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 1012.728 0M12 3v9"/></svg>
@@ -20,7 +23,7 @@
       </button>
     </form>
 {% if request_count > 0 %}
-    <form method="post" action="/apps/{{ app.name }}/requests/clear">
+    <form method="post" action="{{ base }}/requests/clear">
       <button type="submit" data-turbo-confirm="Clear all captured requests?" class="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700 transition-colors">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/></svg>
         Clear All
@@ -82,9 +85,11 @@
 </div>
 {% endif %}
 
+<div id="inspector-config" class="hidden" data-base="{{ base }}" data-app="{{ app.name }}"></div>
 <script>
 (function() {
-  var appId = '{{ app.name }}';
+  var cfg = document.getElementById('inspector-config');
+  var basePath = cfg.dataset.base;
   var tbody = document.getElementById('requests-tbody');
   var activeMethod = '';
   var pathQuery = '';
@@ -158,14 +163,14 @@
 
   // -- SSE --
   {% if app.inspect_enabled %}
-  var evtSource = new EventSource('/apps/' + appId + '/requests/stream');
+  var evtSource = new EventSource(basePath + '/requests/stream');
   evtSource.onmessage = function(e) {
     var d = JSON.parse(e.data);
     var row = document.createElement('tr');
     row.className = 'hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer';
     row.setAttribute('data-method', d.method);
     row.setAttribute('data-path', d.path);
-    row.onclick = function() { window.location = '/apps/' + appId + '/requests/' + d.request_id; };
+    row.onclick = function() { window.location = basePath + '/requests/' + d.request_id; };
 
     var methodColors = {
       'GET': 'bg-blue-50 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',

--- a/crates/coulson/src/dashboard/templates/partials/request_row.html
+++ b/crates/coulson/src/dashboard/templates/partials/request_row.html
@@ -1,4 +1,4 @@
-      <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer" data-method="{{ req.method }}" data-path="{{ req.path }}" onclick="window.location='/apps/{{ app.name }}/requests/{{ req.id }}'">
+      <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer" data-method="{{ req.method }}" data-path="{{ req.path }}" data-href="{{ base | default(value="/apps/" ~ app.name) }}/requests/{{ req.id }}" onclick="window.location=this.dataset.href">
         <td class="px-4 py-2.5 text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap font-mono"><time data-ts="{{ req.timestamp_ms }}"></time></td>
         <td class="px-4 py-2.5">
           <span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-semibold {{ req.method_color }}">{{ req.method }}</span>

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -37,7 +37,7 @@ use tracing::{debug, error, info};
 use tabled::Tabled;
 
 use crate::config::{CoulsonConfig, LOCALHOST_SUFFIX};
-use crate::domain::{BackendTarget, TunnelMode};
+use crate::domain::{AppSpec, BackendTarget, TunnelMode};
 use crate::hooks::{HookContextFactory, HookManager};
 use crate::process::{ProcessManagerHandle, ProviderRegistry};
 use crate::rpc_client::RpcClient;
@@ -78,6 +78,40 @@ pub struct RouteRule {
     pub lan_access: bool,
 }
 
+impl RouteRule {
+    /// Build a `RouteRule` from an `AppSpec`. Used by `reload_routes` (hot
+    /// route table) and by the replay pipeline (which must work even when the
+    /// app is disabled and therefore absent from the route table).
+    pub fn from_app_spec(app: AppSpec) -> Self {
+        let static_root = match &app.target {
+            BackendTarget::Managed { root, .. } => {
+                let public = format!("{root}/public");
+                if std::path::Path::new(&public).is_dir() {
+                    Some(public)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        RouteRule {
+            app_id: Some(app.id.0),
+            inspect_enabled: app.inspect_enabled,
+            lan_access: app.lan_access,
+            target: app.target,
+            path_prefix: app.path_prefix,
+            timeout_ms: app.timeout_ms,
+            cors_enabled: app.cors_enabled,
+            force_https: app.force_https,
+            basic_auth_user: app.basic_auth_user,
+            basic_auth_pass: app.basic_auth_pass,
+            spa_rewrite: app.spa_rewrite,
+            listen_port: app.listen_port,
+            static_root,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SharedState {
     pub store: Arc<AppRepository>,
@@ -104,6 +138,8 @@ pub struct SharedState {
     pub certs_dir: std::path::PathBuf,
     pub runtime_dir: std::path::PathBuf,
     pub hook_manager: Arc<HookManager>,
+    pub inspector_username: Option<String>,
+    pub inspector_password: Option<String>,
     /// Cached privileged-port status with TTL to avoid per-request disk I/O.
     forward_cache: Arc<Mutex<(bool, std::time::Instant)>>,
 }
@@ -164,36 +200,12 @@ impl SharedState {
         let mut table: HashMap<String, Vec<RouteRule>> = HashMap::new();
         let mut port_domains: HashMap<u16, String> = HashMap::new();
         for app in enabled_apps {
-            let static_root = match &app.target {
-                BackendTarget::Managed { root, .. } => {
-                    let public = format!("{root}/public");
-                    if std::path::Path::new(&public).is_dir() {
-                        Some(public)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
             if let Some(port) = app.listen_port {
                 port_domains.insert(port, app.domain.0.clone());
             }
-            let rule = RouteRule {
-                app_id: Some(app.id.0),
-                inspect_enabled: app.inspect_enabled,
-                lan_access: app.lan_access,
-                target: app.target,
-                path_prefix: app.path_prefix,
-                timeout_ms: app.timeout_ms,
-                cors_enabled: app.cors_enabled,
-                force_https: app.force_https,
-                basic_auth_user: app.basic_auth_user,
-                basic_auth_pass: app.basic_auth_pass,
-                spa_rewrite: app.spa_rewrite,
-                listen_port: app.listen_port,
-                static_root,
-            };
-            let domain = app.domain.0;
+            let domain = app.domain.0.clone();
+            let cname = app.cname.clone();
+            let rule = RouteRule::from_app_spec(app);
             // Register .localhost alias so apps are reachable via myapp.localhost
             if self.domain_suffix != LOCALHOST_SUFFIX {
                 if let Some(prefix) = domain.strip_suffix(&format!(".{}", self.domain_suffix)) {
@@ -205,7 +217,7 @@ impl SharedState {
                 }
             }
             // Register cname alias so apps are reachable via custom domain
-            if let Some(ref cname) = app.cname {
+            if let Some(ref cname) = cname {
                 table.entry(cname.clone()).or_default().push(rule.clone());
             }
             table.entry(domain).or_default().push(rule);
@@ -518,6 +530,8 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
         certs_dir: cfg.certs_dir.clone(),
         runtime_dir: cfg.runtime_dir.clone(),
         hook_manager,
+        inspector_username: cfg.inspector_username.clone(),
+        inspector_password: cfg.inspector_password.clone(),
         forward_cache: Arc::new(Mutex::new((
             is_forward_configured_for_port(cfg.listen_http.port()) || is_pf_configured(cfg),
             std::time::Instant::now(),

--- a/crates/coulson/src/process/asgi.rs
+++ b/crates/coulson/src/process/asgi.rs
@@ -62,6 +62,10 @@ impl ProcessProvider for AsgiProvider {
         }
 
         let mut env = std::collections::HashMap::new();
+        // Force unbuffered stdio so uvicorn startup messages and per-request
+        // access logs hit the log file immediately instead of sitting in
+        // Python's block buffer (which kicks in when stdout is a file).
+        env.insert("PYTHONUNBUFFERED".into(), "1".into());
         env.extend(app.env_overrides.clone());
         env.remove("ASGI_RELOAD");
 

--- a/crates/coulson/src/proxy/mod.rs
+++ b/crates/coulson/src/proxy/mod.rs
@@ -45,7 +45,7 @@ async fn mw_auth(session: &mut Session, route: &RouteRule) -> Result<Flow> {
     if via_tunnel {
         if let (Some(user), Some(pass)) = (&route.basic_auth_user, &route.basic_auth_pass) {
             if !check_basic_auth(session, user, pass) {
-                write_auth_required(session).await?;
+                write_auth_required(session, "coulson").await?;
                 return Ok(Flow::Done);
             }
         }
@@ -135,6 +135,235 @@ struct BridgeProxy {
     dashboard_router: axum::Router,
 }
 
+const INSPECTOR_PATH_PREFIX: &str = "/_coulson";
+const EMBEDDED_HEADER: &str = "x-coulson-embedded";
+/// Internal marker header injected by `execute_replay` so the proxy skips
+/// `mw_auth`, `mw_force_https` and inspector capture for replay requests.
+/// Stripped before forwarding to the backend.
+pub const REPLAY_HEADER: &str = "x-coulson-replay";
+
+fn is_inspector_path(path: &str) -> bool {
+    path.starts_with("/_coulson/") || path == "/_coulson"
+}
+
+impl BridgeProxy {
+    /// Handle `/_coulson/` embedded inspector requests.
+    /// Authenticates with independent basic auth, rewrites URI to dashboard paths,
+    /// and bridges to the existing dashboard router.
+    async fn handle_embedded_inspector(
+        &self,
+        session: &mut Session,
+        route: &RouteRule,
+        req_path: &str,
+    ) -> Result<bool> {
+        // Inspector auth: must be configured, otherwise pretend it doesn't exist
+        let (Some(ref user), Some(ref pass)) = (
+            &self.shared.inspector_username,
+            &self.shared.inspector_password,
+        ) else {
+            write_error_page(session, 404, "route_not_found").await?;
+            return Ok(true);
+        };
+
+        // Respect the app's force_https setting — redirect before auth challenge
+        // so credentials are never sent over plain HTTP.
+        if mw_force_https(
+            session,
+            route,
+            self.shared.listen_https.map(|a| a.port()),
+            self.shared.use_default_https_port(),
+        )
+        .await?
+            == Flow::Done
+        {
+            return Ok(true);
+        }
+
+        // Always require basic auth (local + tunnel)
+        if !check_basic_auth(session, user, pass) {
+            write_auth_required(session, "Coulson Inspector").await?;
+            return Ok(true);
+        }
+
+        // Resolve app name from route
+        let app_name = match route.app_id {
+            Some(id) => match self.shared.store.get_by_id(id) {
+                Ok(Some(app)) => app.name,
+                _ => {
+                    write_error_page(session, 404, "route_not_found").await?;
+                    return Ok(true);
+                }
+            },
+            None => {
+                write_error_page(session, 404, "route_not_found").await?;
+                return Ok(true);
+            }
+        };
+
+        // Rewrite URI: /_coulson/... → /apps/{name}/...
+        let sub_path = req_path.strip_prefix(INSPECTOR_PATH_PREFIX).unwrap_or("/");
+        let new_path = if sub_path.is_empty() || sub_path == "/" {
+            format!("/apps/{app_name}/requests")
+        } else {
+            format!("/apps/{app_name}{sub_path}")
+        };
+
+        if let Ok(uri) = new_path.parse::<http::Uri>() {
+            session.req_header_mut().set_uri(uri);
+        }
+
+        // Signal embedded mode to dashboard handlers
+        session
+            .req_header_mut()
+            .insert_header(EMBEDDED_HEADER, "1")?;
+
+        crate::dashboard::bridge(session, self.dashboard_router.clone()).await?;
+        Ok(true)
+    }
+
+    /// Handle a loopback-authenticated replay request pinned to a specific
+    /// app id. The caller already verified `is_loopback_client(session)` and
+    /// stripped `REPLAY_HEADER`. This bypasses host routing — the route is
+    /// looked up by `app_id` directly so `default_app`/CNAME/domain drift
+    /// since capture cannot cause the replay to hit a different app. It also
+    /// skips `mw_auth` and `mw_force_https`, which makes sense because the
+    /// dashboard already authenticated the user and the request is strictly
+    /// in-process over 127.0.0.1.
+    ///
+    /// The route is built directly from `store.get_by_id(app_id)` rather than
+    /// scanned from the live route table. That table only holds *enabled*
+    /// apps (`list_enabled()` in `reload_routes`), so going through it would
+    /// regress replay to 404 whenever a user temporarily disables an app but
+    /// still wants to diagnose an old request from the dashboard.
+    async fn handle_replay_request(
+        &self,
+        session: &mut Session,
+        ctx: &mut ProxyCtx,
+        app_id: i64,
+    ) -> Result<bool> {
+        let req_path = session.req_header().uri.path().to_string();
+
+        // Look up the app by id. Works for disabled apps as well, because the
+        // store does not filter on `enabled`. If the row is gone we genuinely
+        // have nothing to replay against.
+        let app = match self.shared.store.get_by_id(app_id) {
+            Ok(Some(app)) => app,
+            Ok(None) => {
+                write_error_page(session, 404, "route_not_found").await?;
+                return Ok(true);
+            }
+            Err(e) => {
+                tracing::warn!(app_id, error = %e, "replay: failed to load app from store");
+                write_error_page(session, 500, "internal_error").await?;
+                return Ok(true);
+            }
+        };
+
+        let route = RouteRule::from_app_spec(app);
+
+        // The captured request path must still fit the app's configured
+        // `path_prefix`; otherwise the replay would be meaningless (we'd be
+        // sending to an upstream the app was never responsible for).
+        let path_ok = match route.path_prefix.as_deref() {
+            None | Some("/") => true,
+            Some(prefix) => req_path == prefix || req_path.starts_with(&format!("{prefix}/")),
+        };
+        if !path_ok {
+            write_error_page(session, 404, "route_not_found").await?;
+            return Ok(true);
+        }
+
+        // CORS and static lookups still apply — they're not auth checks.
+        if mw_cors(session, &route).await? == Flow::Done {
+            return Ok(true);
+        }
+        if mw_static(session, &route, &req_path).await? == Flow::Done {
+            return Ok(true);
+        }
+
+        // Resolve the concrete upstream target.
+        if let BackendTarget::StaticDir { ref root } = route.target {
+            serve_static(session, root, &req_path, route.cors_enabled).await?;
+            return Ok(true);
+        }
+
+        let resolved_target = if let BackendTarget::Managed {
+            ref app_id,
+            ref root,
+            ref kind,
+            ref name,
+        } = route.target
+        {
+            let root_path = std::path::PathBuf::from(root);
+            let status = crate::process::prepare_and_ensure_started(
+                &self.process_manager,
+                *app_id,
+                name,
+                &root_path,
+                kind,
+            )
+            .await
+            .map_err(|e| Error::explain(ErrorType::ConnectError, format!("{e}")))?;
+            match status {
+                StartStatus::Ready(listen_target) => {
+                    pm_mark_active(&self.process_manager, *app_id).await;
+                    listen_target_to_backend(listen_target)
+                }
+                StartStatus::Starting => {
+                    match await_managed_ready(
+                        session,
+                        &self.process_manager,
+                        *app_id,
+                        name,
+                        &root_path,
+                        kind,
+                    )
+                    .await?
+                    {
+                        Some(target) => target,
+                        None => return Ok(true),
+                    }
+                }
+            }
+        } else {
+            route.target.clone()
+        };
+
+        if route.spa_rewrite && should_rewrite_for_spa(&req_path) {
+            session.req_header_mut().set_uri("/".try_into().unwrap());
+        }
+
+        // Inspector capture — replay is recorded just like any other request,
+        // so users can see what the replay actually sent/received.
+        if route.inspect_enabled {
+            ctx.inspect = true;
+            ctx.inspect_app_id = route.app_id;
+            ctx.inspect_store = Some(self.shared.store.clone());
+            ctx.inspect_max_requests = self.shared.inspect_max_requests;
+            ctx.inspect_tx = Some(self.shared.inspect_tx.clone());
+            ctx.inspect_start = Some(std::time::Instant::now());
+            ctx.inspect_method = Some(session.req_header().method.to_string());
+            let uri = &session.req_header().uri;
+            ctx.inspect_path = Some(uri.path().to_string());
+            ctx.inspect_query = uri.query().map(|q| q.to_string());
+            let headers: std::collections::HashMap<String, String> = session
+                .req_header()
+                .headers
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                .collect();
+            ctx.inspect_req_headers = serde_json::to_string(&headers).ok();
+        }
+
+        ctx.target = Some(resolved_target);
+        ctx.timeout_ms = route.timeout_ms;
+        ctx.cors_enabled = route.cors_enabled;
+        ctx.spa_rewrite = route.spa_rewrite;
+        ctx.is_upgrade = session.req_header().headers.get("upgrade").is_some();
+        Ok(false)
+    }
+}
+
 const INSPECT_BODY_MAX: usize = 65536;
 
 #[derive(Default)]
@@ -173,6 +402,31 @@ impl ProxyHttp for BridgeProxy {
     where
         Self::CTX: Send + Sync,
     {
+        // Replay marker handling. The header carries the captured app's id so
+        // replay is pinned to that specific app, NOT to whatever the current
+        // host routing would resolve to (default_app/CNAME/domain config may
+        // have drifted since capture). The marker is only honored when the
+        // client is a loopback address — otherwise it's a forgery attempt and
+        // we strip it so normal auth/force-https still apply.
+        if session.req_header().headers.contains_key(REPLAY_HEADER) {
+            let header_val = session
+                .req_header()
+                .headers
+                .get(REPLAY_HEADER)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+            // Always strip — the header is internal-only and must never reach
+            // upstream or be re-used by a second hop.
+            session.req_header_mut().remove_header(REPLAY_HEADER);
+            if is_loopback_client(session) {
+                if let Some(app_id) = header_val.as_deref().and_then(|s| s.parse::<i64>().ok()) {
+                    return self.handle_replay_request(session, ctx, app_id).await;
+                }
+            } else {
+                tracing::warn!("rejecting x-coulson-replay header from non-loopback client");
+            }
+        }
+
         // HTTP/2 uses :authority pseudo-header; HTTP/1.1 uses Host header
         let raw_host = session
             .req_header()
@@ -212,6 +466,18 @@ impl ProxyHttp for BridgeProxy {
             if let Some(ref app_domain) = effective_host {
                 // Proxy to default app — strict lookup (no default.{suffix} fallback)
                 let req_path = session.req_header().uri.path().to_string();
+                // Embedded inspector intercept: must run before path_prefix matching
+                if is_inspector_path(&req_path) {
+                    let route = {
+                        let routes = self.shared.routes.read();
+                        any_route(routes.get(app_domain.as_str()))
+                    };
+                    if let Some(route) = route {
+                        return self
+                            .handle_embedded_inspector(session, &route, &req_path)
+                            .await;
+                    }
+                }
                 let route = {
                     let routes = self.shared.routes.read();
                     select_route(routes.get(app_domain.as_str()), &req_path)
@@ -328,6 +594,22 @@ impl ProxyHttp for BridgeProxy {
         }
 
         let req_path = session.req_header().uri.path().to_string();
+
+        // Embedded inspector intercept: must run before route resolution
+        // because /_coulson/ paths won't match app path_prefix rules.
+        if is_inspector_path(&req_path) {
+            let route = {
+                let routes = self.shared.routes.read();
+                resolve_any_route(&routes, &host, &self.shared.domain_suffix)
+            };
+            if let Some(route) = route {
+                return self
+                    .handle_embedded_inspector(session, &route, &req_path)
+                    .await;
+            }
+            write_error_page(session, 404, "route_not_found").await?;
+            return Ok(true);
+        }
 
         let route = {
             let routes = self.shared.routes.read();
@@ -1183,12 +1465,12 @@ fn decode_basic_auth(encoded: &str) -> Option<(String, String)> {
     Some((user.to_string(), pass.to_string()))
 }
 
-async fn write_auth_required(session: &mut Session) -> Result<()> {
+async fn write_auth_required(session: &mut Session, realm: &str) -> Result<()> {
     let body = r#"{"error":"unauthorized"}"#;
     let mut resp = ResponseHeader::build(401, None)?;
     resp.insert_header("content-type", "application/json")?;
     resp.insert_header("content-length", body.len().to_string())?;
-    resp.insert_header("www-authenticate", r#"Basic realm="coulson""#)?;
+    resp.insert_header("www-authenticate", format!(r#"Basic realm="{realm}""#))?;
     resp.insert_header("connection", "close")?;
 
     session.write_response_header(Box::new(resp), false).await?;
@@ -1495,6 +1777,63 @@ fn resolve_target(
     None
 }
 
+/// Like `resolve_target` but ignores path_prefix matching — returns any route
+/// for the host. Used by embedded inspector to identify the app owning a domain
+/// even when no root ("/") route exists.
+fn resolve_any_route(
+    routes: &HashMap<String, Vec<RouteRule>>,
+    host: &str,
+    domain_suffix: &str,
+) -> Option<RouteRule> {
+    if let Some(hit) = any_route(routes.get(host)) {
+        return Some(hit);
+    }
+
+    // Wildcard host matching (e.g. *.example.com)
+    if let Some(hit) = any_wildcard_route(routes, host) {
+        return Some(hit);
+    }
+
+    let mut parts: Vec<&str> = host.split('.').collect();
+    while parts.len() > 2 {
+        parts.remove(0);
+        let candidate = parts.join(".");
+        if let Some(hit) = any_route(routes.get(&candidate)) {
+            return Some(hit);
+        }
+    }
+
+    let default_host = format!("default.{domain_suffix}");
+    if let Some(hit) = any_route(routes.get(&default_host)) {
+        return Some(hit);
+    }
+
+    if domain_suffix != LOCALHOST_SUFFIX && host.ends_with(&format!(".{LOCALHOST_SUFFIX}")) {
+        let default_localhost = format!("default.{LOCALHOST_SUFFIX}");
+        if let Some(hit) = any_route(routes.get(&default_localhost)) {
+            return Some(hit);
+        }
+    }
+
+    None
+}
+
+/// Like `select_wildcard_route` but ignores path_prefix matching.
+fn any_wildcard_route(routes: &HashMap<String, Vec<RouteRule>>, host: &str) -> Option<RouteRule> {
+    let parts: Vec<&str> = host.split('.').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    for i in 1..(parts.len() - 1) {
+        let suffix = parts[i..].join(".");
+        let candidate = format!("*.{suffix}");
+        if let Some(hit) = any_route(routes.get(&candidate)) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
 fn select_wildcard_route(
     routes: &HashMap<String, Vec<RouteRule>>,
     host: &str,
@@ -1528,6 +1867,13 @@ fn select_route(candidates: Option<&Vec<RouteRule>>, path: &str) -> Option<Route
         }
     }
     None
+}
+
+/// Pick any route for a host, ignoring path_prefix matching.
+/// Used by the embedded inspector to identify which app owns a domain.
+/// Returns the shortest-prefix (most general) route as the "default" app.
+fn any_route(candidates: Option<&Vec<RouteRule>>) -> Option<RouteRule> {
+    candidates?.last().cloned()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/coulson/src/service.rs
+++ b/crates/coulson/src/service.rs
@@ -246,6 +246,16 @@ pub fn app_create(state: &SharedState, params: &CreateAppParams) -> Result<AppSp
             "name cannot be empty".to_string(),
         ));
     }
+    if !params
+        .name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(ServiceError::InvalidParams(
+            "name must contain only alphanumeric characters, hyphens, underscores, or dots"
+                .to_string(),
+        ));
+    }
     if params.target_value.is_empty() {
         return Err(ServiceError::InvalidParams(
             "target_value cannot be empty".to_string(),


### PR DESCRIPTION
## Summary
- Adds an embedded inspector mounted at `/_coulson/` so the dashboard can show live request list and per-request detail.
- Inspector entry points (list, detail, replay) are loopback-pinned to prevent exposure via non-local origins.
- Ships requests list page, request detail page, partials, and Turbo Stream wiring for live updates.

## Test plan
- [ ] Start the daemon and open `http://coulson.local:8080/_coulson/requests` — request list should populate live.
- [ ] Click into a request — full request/response detail renders.
- [ ] Trigger replay from the detail page — confirm the replayed request is issued and bound only to loopback.
- [ ] Hit `/_coulson/*` from a non-loopback origin — response must be rejected (404 or equivalent).
- [ ] `cargo test --workspace` passes.