### PR TITLE
feat(dashboard): live log tail SSE with companion process tabs

### DIFF
--- a/crates/coulson/src/dashboard/handlers.rs
+++ b/crates/coulson/src/dashboard/handlers.rs
@@ -28,6 +28,121 @@ fn embedded_base(headers: &HeaderMap, app_name: &str) -> (bool, String) {
     }
 }
 
+/// Return the last `max_lines` lines of `log_path`.
+///
+/// Only reads up to ~1 MiB from the tail, so arbitrarily large log files do
+/// not cause full-file reads. Uses lossy UTF-8 decoding so non-UTF-8 bytes
+/// (ANSI escapes, binary panic traces) are preserved as replacement
+/// characters instead of causing the history to silently disappear.
+fn read_log_tail_lines(log_path: &std::path::Path, max_lines: usize) -> Option<Vec<String>> {
+    use std::io::{Read, Seek, SeekFrom};
+    const TAIL_CAP: u64 = 1 << 20; // 1 MiB
+
+    let mut file = std::fs::File::open(log_path).ok()?;
+    let len = file.metadata().ok()?.len();
+    if len == 0 {
+        return Some(Vec::new());
+    }
+    let start_offset = len.saturating_sub(TAIL_CAP);
+    file.seek(SeekFrom::Start(start_offset)).ok()?;
+    let mut buf = Vec::with_capacity((len - start_offset) as usize);
+    file.read_to_end(&mut buf).ok()?;
+    // If we truncated the head, drop any partial leading line so we never
+    // emit half of a log entry as if it were whole.
+    let slice: &[u8] = if start_offset > 0 {
+        match buf.iter().position(|&b| b == b'\n') {
+            Some(idx) => &buf[idx + 1..],
+            None => &[],
+        }
+    } else {
+        &buf
+    };
+    let text = String::from_utf8_lossy(slice);
+    let lines: Vec<String> = text.lines().map(str::to_string).collect();
+    let start = lines.len().saturating_sub(max_lines);
+    Some(lines[start..].to_vec())
+}
+
+/// Lexically normalize a path: collapse `.` / `..` / redundant separators
+/// WITHOUT touching the filesystem.
+///
+/// Needed because companion-log collision detection must work even when the
+/// log files do not yet exist (e.g. the companion process has never been
+/// spawned). `std::fs::canonicalize` requires the target to exist, so it is
+/// unsuitable here. Lexical normalization is also deliberately unaware of
+/// symlinks — two different symlinks to the same inode will compare unequal,
+/// which is the safer default for config-level collision detection.
+fn lexical_normalize(p: &std::path::Path) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => out.push(comp.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => match out.components().next_back() {
+                // Collapse against the preceding real segment.
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                // On an absolute path `/..` equals `/` — drop the extra
+                // ParentDir entirely instead of keeping it as `/../…`,
+                // otherwise two spellings of the same real file would
+                // normalize to different `PathBuf`s and escape
+                // `companion_log_collides`.
+                Some(Component::RootDir) | Some(Component::Prefix(_)) => {}
+                // Relative path with no preceding `Normal` (either empty
+                // or already a `..` chain): preserve the `..` so the
+                // meaning of the relative path is kept.
+                _ => {
+                    out.push("..");
+                }
+            },
+            Component::Normal(s) => out.push(s),
+        }
+    }
+    out
+}
+
+/// Collect lexically-normalized web log paths for every managed app OTHER
+/// than `self_name`.
+///
+/// Used to detect file-path level collisions between a would-be companion
+/// log (`{self}-{ptype}.log`) and some unrelated app's web log. Iterating
+/// the full managed-app set is required because any app — regardless of
+/// name — can point its manifest `log_path` at the same file. Returns
+/// Err on store failure; callers should fail closed.
+fn other_managed_web_log_paths(
+    shared: &SharedState,
+    self_name: &str,
+) -> anyhow::Result<std::collections::HashSet<std::path::PathBuf>> {
+    let sockets_dir = shared.runtime_dir.join("managed");
+    let mut out = std::collections::HashSet::new();
+    for app in shared.store.list_all()? {
+        if app.name == self_name {
+            continue;
+        }
+        let crate::domain::BackendTarget::Managed { root, .. } = &app.target else {
+            continue;
+        };
+        let root_path = std::path::PathBuf::from(root);
+        let manifest = crate::process::load_coulson_toml_manifest(&root_path);
+        let web_log =
+            crate::process::resolve_log_path(&manifest, &root_path, &sockets_dir, &app.name);
+        out.insert(lexical_normalize(&web_log));
+    }
+    Ok(out)
+}
+
+/// Whether `companion_path` would read some other managed app's web log
+/// file. Pure set-membership on normalized paths — compute the set via
+/// [`other_managed_web_log_paths`] once per request and reuse it.
+fn companion_log_collides(
+    other_paths: &std::collections::HashSet<std::path::PathBuf>,
+    companion_path: &std::path::Path,
+) -> bool {
+    other_paths.contains(&lexical_normalize(companion_path))
+}
+
 pub async fn favicon() -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -564,11 +679,7 @@ pub async fn page_process_log(
         }
         _ => sockets_dir.join(format!("{}.log", app.name)),
     };
-    let log_content = std::fs::read_to_string(&log_path).ok().map(|content| {
-        let lines: Vec<&str> = content.lines().collect();
-        let start = lines.len().saturating_sub(200);
-        lines[start..].join("\n")
-    });
+    let log_content = read_log_tail_lines(&log_path, 200).map(|lines| lines.join("\n"));
     let page = render_page("pages/process_log.html", &state.shared, |ctx| {
         ctx.insert("title", &format!("{} — Log", app.name));
         ctx.insert("active_nav", "processes");
@@ -1004,6 +1115,441 @@ pub async fn action_set_tunnel_mode(
     StatusCode::NO_CONTENT.into_response()
 }
 
+pub async fn page_logs(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    let app = match state.shared.store.get_by_name(&id) {
+        Ok(Some(app)) => app,
+        _ => return html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared)),
+    };
+
+    let port = state.shared.listen_http.port();
+    let app_view = AppView::from_spec(&app, port, state.shared.use_default_http_port());
+    let (embedded, base_path) = embedded_base(&headers, &app.name);
+
+    // Only managed apps have logs
+    let root = match &app.target {
+        crate::domain::BackendTarget::Managed { root, .. } => std::path::PathBuf::from(root),
+        _ => {
+            let page = render_page("pages/log_tail.html", &state.shared, |ctx| {
+                ctx.insert("title", &format!("{} — Logs", app.name));
+                ctx.insert("app", &app_view);
+                ctx.insert("unsupported", &true);
+                ctx.insert("embedded", &embedded);
+                ctx.insert("base_path", &base_path);
+                ctx.insert("full_width", &true);
+            });
+            return Html(page).into_response();
+        }
+    };
+
+    let sockets_dir = state.shared.runtime_dir.join("managed");
+    let manifest = crate::process::load_coulson_toml_manifest(&root);
+    let log_path = crate::process::resolve_log_path(&manifest, &root, &sockets_dir, &app.name);
+
+    let runtime_types = {
+        let pm = state.shared.process_manager.lock().await;
+        pm.process_types(app.id.0)
+    };
+
+    // Determine whether a companion log candidate would actually share a
+    // file path with some OTHER app's resolved web log. Scan every managed
+    // app (not just `{name}-{ptype}`) because any app, regardless of name,
+    // can point its manifest `log_path` at the same file. Fail closed on
+    // store error so a transient DB hiccup never exposes another app's log.
+    let log_dir = log_path.parent().unwrap_or(&sockets_dir);
+    let other_paths = match other_managed_web_log_paths(&state.shared, &app.name) {
+        Ok(set) => Some(set),
+        Err(e) => {
+            tracing::warn!(error = %e, app = %app.name, "store lookup failed; hiding all companion log tabs");
+            None
+        }
+    };
+    let collides = |ptype: &str| -> bool {
+        if ptype == "web" {
+            return false;
+        }
+        let stem = format!("{}-{}", app.name, ptype);
+        let companion_path = log_dir.join(format!("{stem}.log"));
+        match &other_paths {
+            Some(set) => companion_log_collides(set, &companion_path),
+            None => true,
+        }
+    };
+
+    // Filter runtime types so the page and the SSE endpoint agree on
+    // which companions are reachable. Without this, a genuinely-colliding
+    // companion would appear as a tab here but 404 when clicked.
+    let runtime_types: Vec<String> = runtime_types.into_iter().filter(|t| !collides(t)).collect();
+
+    // Scan the log directory for any companion log files
+    // (`{name}.log`, `{name}-{ptype}.log`) so we can offer switchers for
+    // worker/scheduler/etc. even if the process is not currently running.
+    // Skip any candidate whose file path would actually overlap with
+    // another registered app's web log — `foo-worker.log` (the web log of
+    // `foo-worker`) would otherwise be misread as `foo`'s `worker`
+    // companion when both apps share `{sockets_dir}` as their log dir.
+    let mut disk_types: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(log_dir) {
+        for entry in entries.flatten() {
+            let fname_os = entry.file_name();
+            let Some(fname) = fname_os.to_str() else {
+                continue;
+            };
+            if fname == format!("{}.log", app.name) {
+                disk_types.push("web".to_string());
+            } else if let Some(rest) = fname.strip_prefix(&format!("{}-", app.name)) {
+                if let Some(ptype) = rest.strip_suffix(".log") {
+                    // Skip files whose inferred `ptype` does not match the
+                    // process_type charset. Without this a legit log like
+                    // `foo-bar.baz.log` (left by some unrelated tool or
+                    // historical data) would surface as a `bar.baz` tab that
+                    // `sse_logs` would then reject anyway — an avoidable
+                    // "tab shown then 404" inconsistency.
+                    if !crate::process::is_valid_process_type(ptype) {
+                        continue;
+                    }
+                    if collides(ptype) {
+                        continue;
+                    }
+                    disk_types.push(ptype.to_string());
+                }
+            }
+        }
+    }
+
+    // Merge runtime + disk types, keeping order; dedupe; force "web" first.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut process_types: Vec<String> = Vec::new();
+    for t in runtime_types.iter().chain(disk_types.iter()) {
+        if seen.insert(t.clone()) {
+            process_types.push(t.clone());
+        }
+    }
+    if process_types.is_empty() {
+        process_types.push("web".to_string());
+    } else if let Some(pos) = process_types.iter().position(|x| x == "web") {
+        if pos != 0 {
+            process_types.swap(0, pos);
+        }
+    }
+
+    // Map each process_type to its on-disk log path so the UI can update
+    // the displayed filename when the user switches tabs — the primary
+    // `log_path` only describes the `web` log, while companions live at
+    // `{log_dir}/{name}-{ptype}.log` (matching `spawn_tee_task`'s target).
+    let mut process_log_paths: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
+    for pt in &process_types {
+        let p = if pt == "web" {
+            log_path.clone()
+        } else {
+            log_dir.join(format!("{}-{}.log", app.name, pt))
+        };
+        process_log_paths.insert(pt.clone(), p.to_string_lossy().into_owned());
+    }
+    let initial_process = process_types
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "web".to_string());
+    let initial_log_path = process_log_paths
+        .get(&initial_process)
+        .cloned()
+        .unwrap_or_else(|| log_path.to_string_lossy().into_owned());
+
+    let page = render_page("pages/log_tail.html", &state.shared, |ctx| {
+        ctx.insert("title", &format!("{} — Logs", app.name));
+        ctx.insert("app", &app_view);
+        ctx.insert("log_path", &initial_log_path);
+        ctx.insert("initial_process", &initial_process);
+        ctx.insert("process_log_paths", &process_log_paths);
+        ctx.insert("process_types", &process_types);
+        ctx.insert("embedded", &embedded);
+        ctx.insert("base_path", &base_path);
+        ctx.insert("full_width", &true);
+    });
+    Html(page).into_response()
+}
+
+pub async fn sse_logs_default(
+    state: State<DashboardState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    sse_logs(state, headers, Path((id, "web".to_string()))).await
+}
+
+pub async fn sse_logs(
+    State(state): State<DashboardState>,
+    headers: HeaderMap,
+    Path((id, process_type)): Path<(String, String)>,
+) -> Response {
+    let app = match state.shared.store.get_by_name(&id) {
+        Ok(Some(app)) => app,
+        _ => return html_response(StatusCode::NOT_FOUND, "Not found".to_string()),
+    };
+
+    // Reject process_types that would escape the `{name}-{ptype}.log`
+    // filename into a nested path or non-ASCII filesystem segment. "web"
+    // is the only companion-less case that bypasses the log-name format,
+    // so it is always admitted even though it also matches the charset.
+    if process_type != "web" && !crate::process::is_valid_process_type(&process_type) {
+        return html_response(StatusCode::NOT_FOUND, "Not found".to_string());
+    }
+
+    // EventSource sends Accept: text/event-stream; plain curl does not.
+    let want_sse = headers
+        .get("accept")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.contains("text/event-stream"));
+
+    // Resolve the log file path for this process_type. The web log follows
+    // the manifest's log_path; companion logs live in the same directory as
+    // `{name}-{ptype}.log`.
+    let root = match &app.target {
+        crate::domain::BackendTarget::Managed { root, .. } => std::path::PathBuf::from(root),
+        _ => {
+            if want_sse {
+                return Sse::new(futures::stream::pending::<Result<Event, Infallible>>())
+                    .keep_alive(KeepAlive::default())
+                    .into_response();
+            }
+            return plain_text_stream(futures::stream::pending::<String>());
+        }
+    };
+    let sockets_dir = state.shared.runtime_dir.join("managed");
+    let manifest = crate::process::load_coulson_toml_manifest(&root);
+    let web_log = crate::process::resolve_log_path(&manifest, &root, &sockets_dir, &app.name);
+    // Refuse companion process_types whose resolved log path would actually
+    // overlap another registered app's web log. Compare resolved paths (not
+    // just names) so a `foo-worker` app with a manifest `log_path` pointing
+    // elsewhere does not block `foo`'s legitimate `worker` companion. Fail
+    // closed on store error: we would rather 404 than leak another app's
+    // log during a transient DB hiccup.
+    let log_path = if process_type == "web" {
+        web_log.clone()
+    } else {
+        web_log
+            .parent()
+            .unwrap_or(&sockets_dir)
+            .join(format!("{}-{}.log", app.name, process_type))
+    };
+    if process_type != "web" {
+        let collides = match other_managed_web_log_paths(&state.shared, &app.name) {
+            Ok(set) => companion_log_collides(&set, &log_path),
+            Err(e) => {
+                tracing::warn!(error = %e, app = %app.name, "store lookup failed; refusing companion log stream");
+                true
+            }
+        };
+        if collides {
+            return html_response(StatusCode::NOT_FOUND, "Not found".to_string());
+        }
+    }
+
+    let has_broadcast = {
+        let pm = state.shared.process_manager.lock().await;
+        pm.has_log_broadcast()
+    };
+
+    let app_id = app.id.0;
+    let ptype_for_filter = process_type.clone();
+
+    // Subscribe / capture live cursor BEFORE reading history so no lines are
+    // lost in the window between the file read and the live stream
+    // starting. Any overlap is tolerable — duplicated lines look
+    // harmless — but a missed line is invisible and confusing.
+    if has_broadcast {
+        let rx = state.shared.log_tx.subscribe();
+        let history = read_log_tail_lines(&log_path, 200).unwrap_or_default();
+        let history_stream = futures::stream::iter(history);
+        let live_stream = BroadcastStream::new(rx).filter_map(move |result| match result {
+            Ok(log_line)
+                if log_line.app_id == app_id && log_line.process_type == ptype_for_filter =>
+            {
+                Some(log_line.line)
+            }
+            _ => None,
+        });
+        if want_sse {
+            // Tag history events so the client can skip the fade-in animation
+            // for replayed lines (only real-time lines should animate).
+            let history_events = history_stream
+                .map(|line| Ok::<_, Infallible>(Event::default().event("history").data(line)));
+            let live_events =
+                live_stream.map(|line| Ok::<_, Infallible>(Event::default().data(line)));
+            let stream = history_events.chain(live_events);
+            Sse::new(stream)
+                .keep_alive(KeepAlive::default())
+                .into_response()
+        } else {
+            plain_text_stream(history_stream.chain(live_stream))
+        }
+    } else {
+        // Tmux fallback: poll the companion log file for new lines.
+        //
+        // Capture the live cursor (current file length) BEFORE reading
+        // history. Any lines written between the two reads end up in
+        // history AND in the next poll — duplicates are tolerable, gaps
+        // are not.
+        let initial_offset = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+        let history = read_log_tail_lines(&log_path, 200).unwrap_or_default();
+        let history_stream = futures::stream::iter(history);
+
+        struct TailState {
+            path: std::path::PathBuf,
+            offset: u64,
+            pending: std::collections::VecDeque<String>,
+            // When we read a chunk with no newline and below the
+            // `POLL_CAP`, remember the file length we saw. If the next
+            // poll still sees the exact same length, the writer has
+            // gone quiet (e.g. the process exited leaving a trailing
+            // line without `\n`) and we flush the buffered tail as a
+            // synthetic line instead of hiding it forever.
+            stale_len: Option<u64>,
+        }
+
+        let tail = TailState {
+            path: log_path,
+            offset: initial_offset,
+            pending: std::collections::VecDeque::new(),
+            stale_len: None,
+        };
+
+        let live_stream = futures::stream::unfold(tail, |mut st| async move {
+            // Cap a single poll so a large append spike cannot balloon
+            // into an unbounded allocation.
+            const POLL_CAP: u64 = 1 << 20; // 1 MiB
+
+            loop {
+                if let Some(line) = st.pending.pop_front() {
+                    return Some((line, st));
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                let Ok(mut file) = std::fs::File::open(&st.path) else {
+                    continue;
+                };
+                let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+                if len <= st.offset {
+                    // File shrank or has no new bytes — reset quiescence
+                    // tracking; there is nothing buffered to flush.
+                    st.stale_len = None;
+                    continue;
+                }
+                use std::io::{Read, Seek, SeekFrom};
+                if file.seek(SeekFrom::Start(st.offset)).is_err() {
+                    continue;
+                }
+                let to_read = std::cmp::min(len - st.offset, POLL_CAP) as usize;
+                let mut chunk = vec![0u8; to_read];
+                let n = file.read(&mut chunk).unwrap_or(0);
+                if n == 0 {
+                    continue;
+                }
+                chunk.truncate(n);
+                // Mirror `spawn_tee_task`: split on `\n`, decode each
+                // line with `from_utf8_lossy` so non-UTF-8 bytes survive
+                // instead of aborting the tail. Prefer tail -f semantics
+                // (only advance past complete newlines), but guard
+                // against two failure modes: a `POLL_CAP`-sized chunk
+                // with no newline would otherwise stall the stream, and
+                // a trailing unterminated fragment after the writer has
+                // exited would otherwise be hidden forever.
+                match chunk.iter().rposition(|&b| b == b'\n') {
+                    Some(last_nl) => {
+                        let consumable = &chunk[..=last_nl];
+                        let mut line_start = 0;
+                        for (i, b) in consumable.iter().enumerate() {
+                            if *b == b'\n' {
+                                let slice = &consumable[line_start..i];
+                                let slice = if slice.last() == Some(&b'\r') {
+                                    &slice[..slice.len() - 1]
+                                } else {
+                                    slice
+                                };
+                                st.pending
+                                    .push_back(String::from_utf8_lossy(slice).into_owned());
+                                line_start = i + 1;
+                            }
+                        }
+                        st.offset += (last_nl + 1) as u64;
+                        st.stale_len = None;
+                    }
+                    None if n as u64 == POLL_CAP => {
+                        // Chunk completely fills the cap with no newline:
+                        // emit it as a synthetic line and advance past
+                        // it so the tail keeps moving. Any partial
+                        // fragment still buffered upstream will be
+                        // flushed on the next write.
+                        st.pending
+                            .push_back(String::from_utf8_lossy(&chunk).into_owned());
+                        st.offset += n as u64;
+                        st.stale_len = None;
+                    }
+                    None if st.stale_len == Some(len) => {
+                        // Second poll observing the same file length with
+                        // no newline — the writer has gone quiet. Flush
+                        // the buffered tail as a synthetic line so a
+                        // process that exited mid-line (crash, prompt,
+                        // tool output without trailing `\n`) still shows
+                        // up in the live view.
+                        st.pending
+                            .push_back(String::from_utf8_lossy(&chunk).into_owned());
+                        st.offset += n as u64;
+                        st.stale_len = None;
+                    }
+                    None => {
+                        // First time we see this partial tail. Remember
+                        // the file length and wait one more poll —
+                        // active writers virtually always continue
+                        // within 1 s, so this only triggers once output
+                        // has actually stopped.
+                        st.stale_len = Some(len);
+                        continue;
+                    }
+                }
+            }
+        });
+
+        if want_sse {
+            let history_events = history_stream
+                .map(|line| Ok::<_, Infallible>(Event::default().event("history").data(line)));
+            let live_events =
+                live_stream.map(|line| Ok::<_, Infallible>(Event::default().data(line)));
+            let stream = history_events.chain(live_events);
+            Sse::new(stream)
+                .keep_alive(KeepAlive::default())
+                .into_response()
+        } else {
+            plain_text_stream(history_stream.chain(live_stream))
+        }
+    }
+}
+
+/// Wrap a `Stream<Item = String>` into a chunked `text/plain` response (one line per chunk).
+fn plain_text_stream<S>(stream: S) -> Response
+where
+    S: futures::Stream<Item = String> + Send + 'static,
+{
+    use axum::body::Body;
+
+    let body_stream = stream.map(|line| Ok::<_, Infallible>(format!("{line}\n")));
+    let body = Body::from_stream(body_stream);
+    (
+        [
+            (
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; charset=utf-8",
+            ),
+            (axum::http::header::CACHE_CONTROL, "no-cache"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
 pub async fn not_found(
     State(state): State<DashboardState>,
     request: axum::extract::Request,
@@ -1015,4 +1561,51 @@ pub async fn not_found(
         );
     }
     html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lexical_normalize;
+    use std::path::{Path, PathBuf};
+
+    fn norm(p: &str) -> PathBuf {
+        lexical_normalize(Path::new(p))
+    }
+
+    #[test]
+    fn normalizes_curdir_and_simple_parent() {
+        assert_eq!(norm("./logs/../foo.log"), PathBuf::from("foo.log"));
+        assert_eq!(norm("a/b/../c"), PathBuf::from("a/c"));
+    }
+
+    #[test]
+    fn preserves_relative_parent_chain() {
+        assert_eq!(norm("../foo"), PathBuf::from("../foo"));
+        assert_eq!(norm("../../foo/bar"), PathBuf::from("../../foo/bar"));
+    }
+
+    #[test]
+    fn collapses_extra_parents_above_root() {
+        // `/..` is `/` on Unix — extra ParentDir above RootDir must not
+        // survive into the normalized path, otherwise two spellings of
+        // the same real file compare unequal.
+        assert_eq!(
+            norm("/tmp/../../tmp/foo.log"),
+            PathBuf::from("/tmp/foo.log")
+        );
+        assert_eq!(norm("/.."), PathBuf::from("/"));
+        assert_eq!(norm("/../.."), PathBuf::from("/"));
+    }
+
+    #[test]
+    fn strips_trailing_separator() {
+        assert_eq!(norm("a/b/"), PathBuf::from("a/b"));
+        assert_eq!(norm("/tmp/"), PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn absolute_and_root_edge_cases() {
+        assert_eq!(norm("/"), PathBuf::from("/"));
+        assert_eq!(norm("/tmp/foo.log"), PathBuf::from("/tmp/foo.log"));
+    }
 }

--- a/crates/coulson/src/dashboard/mod.rs
+++ b/crates/coulson/src/dashboard/mod.rs
@@ -57,6 +57,12 @@ pub fn router(state: DashboardState) -> Router {
         .route("/apps/{id}", get(handlers::page_app_detail))
         .route("/apps/{id}/requests", get(handlers::page_requests))
         .route("/apps/{id}/requests/stream", get(handlers::sse_requests))
+        .route("/apps/{id}/logs", get(handlers::page_logs))
+        .route("/apps/{id}/logs/stream", get(handlers::sse_logs_default))
+        .route(
+            "/apps/{id}/logs/stream/{process_type}",
+            get(handlers::sse_logs),
+        )
         .route(
             "/apps/{id}/requests/{req_id}",
             get(handlers::page_request_detail),
@@ -194,11 +200,9 @@ pub async fn bridge(session: &mut Session, dashboard_router: Router) -> Result<(
         .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
         .collect();
 
-    let is_sse = headers
-        .iter()
-        .any(|(k, v)| k == "content-type" && v.contains("text/event-stream"));
+    let is_streaming = !headers.iter().any(|(k, _)| k == "content-length");
 
-    if is_sse {
+    if is_streaming {
         let mut resp = ResponseHeader::build(status_code, None)?;
         copy_headers(&mut resp, &headers, true)?;
         session.write_response_header(Box::new(resp), false).await?;

--- a/crates/coulson/src/dashboard/render.rs
+++ b/crates/coulson/src/dashboard/render.rs
@@ -145,6 +145,10 @@ pub fn templates() -> &'static Tera {
                     "partials/lan_toggle.html",
                     include_str!("templates/partials/lan_toggle.html"),
                 ),
+                (
+                    "pages/log_tail.html",
+                    include_str!("templates/pages/log_tail.html"),
+                ),
             ])
             .expect("template parse error");
             tera.autoescape_on(vec![".html"]);

--- a/crates/coulson/src/dashboard/templates/base.html
+++ b/crates/coulson/src/dashboard/templates/base.html
@@ -78,7 +78,7 @@ Stimulus.register("modal", class extends Controller {
   </div>
 </header>
 {% endif %}
-<main class="flex-1 mx-auto max-w-6xl w-full px-6 py-8">
+<main class="flex-1 mx-auto w-full px-6 {% if embedded %}py-3{% else %}py-8{% endif %} {% if full_width %}max-w-none{% else %}max-w-6xl{% endif %}">
 {% block content %}{% endblock content %}
 </main>
 {% if not embedded %}<footer class="border-t border-zinc-200 dark:border-zinc-800 mt-auto">

--- a/crates/coulson/src/dashboard/templates/pages/log_tail.html
+++ b/crates/coulson/src/dashboard/templates/pages/log_tail.html
@@ -1,0 +1,227 @@
+{% extends "base.html" %}
+{% block content %}
+{% set base = base_path | default(value="/apps/" ~ app.name) %}
+{% if not embedded %}
+<a href="/processes" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 mb-6 transition-colors"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5"/></svg>Back to Processes</a>
+{% endif %}
+
+{% if unsupported %}
+{% if not embedded %}
+<div class="mb-8">
+  <h1 class="text-2xl font-semibold tracking-tight">Process Log</h1>
+  <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{{ app.name }}</p>
+</div>
+{% endif %}
+<div class="rounded-xl border border-zinc-200 bg-white p-12 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">This app is a port proxy or static directory and does not have process logs.</p>
+</div>
+{% else %}
+{% if embedded %}
+<div class="flex items-center justify-between gap-3 mb-2">
+  <div class="flex items-center gap-3 min-w-0 flex-1">
+{% if process_types | length > 1 %}
+    <div class="flex gap-1 flex-shrink-0" id="process-tabs">
+{% for pt in process_types %}
+      <button data-process="{{ pt }}" class="text-xs font-medium px-2.5 py-1 rounded-md transition-colors {% if loop.first %}bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100{% else %}text-zinc-600 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800/50{% endif %}">{{ pt }}</button>
+{% endfor %}
+    </div>
+{% endif %}
+{% if log_path %}
+    <div id="log-path-display" class="text-xs text-zinc-400 dark:text-zinc-500 font-mono truncate" title="{{ log_path }}">{{ log_path }}</div>
+{% endif %}
+  </div>
+  <span id="sse-status" class="inline-flex items-center gap-1.5 text-xs text-zinc-400 dark:text-zinc-500 flex-shrink-0">
+    <span id="sse-dot" class="h-1.5 w-1.5 rounded-full bg-zinc-300 dark:bg-zinc-600"></span>
+    <span id="sse-label">Connecting</span>
+  </span>
+</div>
+{% else %}
+<div class="mb-6">
+  <div class="flex items-start justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold tracking-tight">Process Log</h1>
+      <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{{ app.name }}{% if log_path %} — <span id="log-path-display" class="font-mono">{{ log_path }}</span>{% endif %}</p>
+    </div>
+    <div class="flex items-center gap-2">
+      <span id="sse-status" class="inline-flex items-center gap-1.5 text-xs text-zinc-400 dark:text-zinc-500">
+        <span id="sse-dot" class="h-1.5 w-1.5 rounded-full bg-zinc-300 dark:bg-zinc-600"></span>
+        <span id="sse-label">Connecting</span>
+      </span>
+    </div>
+  </div>
+{% if process_types | length > 1 %}
+  <div class="mt-4 flex gap-1" id="process-tabs">
+{% for pt in process_types %}
+    <button data-process="{{ pt }}" class="text-sm font-medium px-3 py-1.5 rounded-md transition-colors {% if loop.first %}bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100{% else %}text-zinc-600 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800/50{% endif %}">{{ pt }}</button>
+{% endfor %}
+  </div>
+{% endif %}
+</div>
+{% endif %}
+
+<div id="log-scroll" style="max-height:{% if embedded %}calc(100vh - 120px){% else %}78vh{% endif %};overflow-y:auto" class="rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 px-4 py-3">
+  <div id="log-lines">
+    <p id="log-placeholder" class="text-sm text-zinc-400 dark:text-zinc-500">Loading…</p>
+  </div>
+</div>
+<style>
+.log-line {
+  border-left: 2px solid transparent;
+  padding-left: 8px;
+}
+@keyframes coulsonLogAccent {
+  0%, 75% { border-left-color: rgb(16, 185, 129); }
+  100%    { border-left-color: transparent; }
+}
+.log-line-new { animation: coulsonLogAccent 2.5s ease-out forwards; }
+</style>
+
+<div id="log-stream-config" class="hidden" data-base-path="{{ base }}" data-initial-process="{{ initial_process | default(value='web') }}" data-process-paths="{{ process_log_paths | default(value='{}') | json_encode }}"></div>
+<script>
+(function() {
+  var cfg = document.getElementById('log-stream-config');
+  var basePath = cfg ? cfg.dataset.basePath : '';
+  var initialProcess = (cfg && cfg.dataset.initialProcess) ? cfg.dataset.initialProcess : 'web';
+  var processPaths = {};
+  if (cfg && cfg.dataset.processPaths) {
+    try { processPaths = JSON.parse(cfg.dataset.processPaths) || {}; } catch (e) { processPaths = {}; }
+  }
+  var logScroll = document.getElementById('log-scroll');
+  var logLines = document.getElementById('log-lines');
+  var logPathDisplay = document.getElementById('log-path-display');
+  var sseDot = document.getElementById('sse-dot');
+  var sseLabel = document.getElementById('sse-label');
+  var evtSource = null;
+  var currentProcess = initialProcess;
+  var autoScroll = true;
+  var logLineClass = 'log-line m-0 text-xs font-mono text-zinc-700 dark:text-zinc-300 whitespace-pre-wrap break-all leading-relaxed';
+
+  function updateLogPathDisplay(process) {
+    if (!logPathDisplay) return;
+    var p = processPaths[process];
+    if (typeof p !== 'string' || !p) return;
+    logPathDisplay.textContent = p;
+    logPathDisplay.setAttribute('title', p);
+  }
+
+  function isNearBottom() {
+    return logScroll.scrollHeight - logScroll.scrollTop - logScroll.clientHeight < 80;
+  }
+
+  logScroll.addEventListener('scroll', function() {
+    autoScroll = isNearBottom();
+  });
+
+  function scrollEntryIntoView(entry) {
+    requestAnimationFrame(function() {
+      logScroll.scrollTop = logScroll.scrollHeight;
+      if (entry && entry.scrollIntoView) {
+        entry.scrollIntoView({ block: 'end' });
+      }
+    });
+  }
+
+  function clearPlaceholder() {
+    var placeholder = document.getElementById('log-placeholder');
+    if (placeholder) {
+      placeholder.remove();
+    }
+  }
+
+  function appendLogEntry(text, animate) {
+    var shouldStick = autoScroll || isNearBottom();
+    var entry = document.createElement('pre');
+
+    clearPlaceholder();
+
+    entry.className = logLineClass + (animate ? ' log-line-new' : '');
+    entry.textContent = text;
+    logLines.appendChild(entry);
+
+    if (shouldStick) {
+      scrollEntryIntoView(entry);
+    }
+  }
+
+  function setStatus(status) {
+    if (status === 'connected') {
+      sseDot.className = 'h-1.5 w-1.5 rounded-full bg-emerald-500';
+      sseLabel.textContent = 'Live';
+    } else if (status === 'connecting') {
+      sseDot.className = 'h-1.5 w-1.5 rounded-full bg-zinc-300 dark:bg-zinc-600';
+      sseLabel.textContent = 'Connecting';
+    } else {
+      sseDot.className = 'h-1.5 w-1.5 rounded-full bg-red-400';
+      sseLabel.textContent = 'Disconnected';
+    }
+  }
+
+  function resetLog(placeholderText) {
+    logLines.textContent = '';
+    var p = document.createElement('p');
+    p.id = 'log-placeholder';
+    p.className = 'text-sm text-zinc-400 dark:text-zinc-500';
+    p.textContent = placeholderText;
+    logLines.appendChild(p);
+  }
+
+  function connect(process) {
+    if (evtSource) { evtSource.close(); }
+    currentProcess = process;
+    updateLogPathDisplay(process);
+    setStatus('connecting');
+    autoScroll = true;
+    resetLog('Loading ' + process + '…');
+    evtSource = new EventSource(basePath + '/logs/stream/' + encodeURIComponent(process));
+    evtSource.onopen = function() { setStatus('connected'); };
+    // Replayed history lines: no animation.
+    evtSource.addEventListener('history', function(e) {
+      appendLogEntry(e.data, false);
+    });
+    // Default `message` event = real-time: fade in.
+    evtSource.onmessage = function(e) {
+      appendLogEntry(e.data, true);
+    };
+    evtSource.onerror = function() { setStatus('disconnected'); };
+  }
+
+  // Event-delegated tab switching. Using data-process + addEventListener
+  // (rather than inline onclick="switchProcess('{{ pt }}', ...)") keeps
+  // the process_type value out of any JS string context, so a malformed
+  // name like `worker');alert(1);//` cannot break out of an onclick
+  // attribute. Active/inactive class strings are captured from whatever
+  // the template rendered, so the same handler works in both the
+  // embedded (text-xs) and standalone (text-sm) modes without hardcoding
+  // a size-specific class list.
+  var processTabs = document.getElementById('process-tabs');
+  if (processTabs) {
+    var tabButtons = processTabs.querySelectorAll('button[data-process]');
+    var activeClass = null;
+    var inactiveClass = null;
+    tabButtons.forEach(function(btn, i) {
+      if (i === 0) activeClass = btn.className;
+      else if (inactiveClass === null) inactiveClass = btn.className;
+    });
+    processTabs.addEventListener('click', function(e) {
+      var btn = e.target.closest('button[data-process]');
+      if (!btn || !processTabs.contains(btn)) return;
+      var process = btn.dataset.process;
+      if (!process) return;
+      if (activeClass !== null && inactiveClass !== null) {
+        tabButtons.forEach(function(t) {
+          t.className = t === btn ? activeClass : inactiveClass;
+        });
+      }
+      connect(process);
+    });
+  }
+
+  connect(currentProcess);
+
+  document.addEventListener('turbo:before-visit', function() {
+    if (evtSource) evtSource.close();
+  }, { once: true });
+})();
+</script>
+{% endif %}
+{% endblock content %}

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -134,6 +134,7 @@ pub struct SharedState {
     pub share_signer: Arc<ShareSigner>,
     pub inspect_max_requests: usize,
     pub inspect_tx: broadcast::Sender<InspectEvent>,
+    pub log_tx: broadcast::Sender<crate::process::LogLine>,
     pub network_change_tx: broadcast::Sender<()>,
     pub certs_dir: std::path::PathBuf,
     pub runtime_dir: std::path::PathBuf,
@@ -471,6 +472,7 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
 
     let share_signer = Arc::new(ShareSigner::load_or_generate(&store)?);
     let (inspect_tx, _) = broadcast::channel(256);
+    let (log_tx, _) = broadcast::channel::<crate::process::LogLine>(512);
     let (network_change_tx, _) = broadcast::channel(4);
     let idle_timeout = Duration::from_secs(cfg.idle_timeout_secs);
     let registry = Arc::new(process::default_registry());
@@ -503,6 +505,7 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
         backend: cfg.process_backend,
         hook_manager: Arc::clone(&hook_manager),
         hook_factory: pm_hook_factory,
+        log_tx: log_tx.clone(),
     });
 
     Ok(SharedState {
@@ -526,6 +529,7 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
         share_signer,
         inspect_max_requests: cfg.inspect_max_requests,
         inspect_tx,
+        log_tx: log_tx.clone(),
         network_change_tx,
         certs_dir: cfg.certs_dir.clone(),
         runtime_dir: cfg.runtime_dir.clone(),

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use tokio::process::{Child, Command};
+use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
 use std::process::Stdio;
@@ -26,6 +27,14 @@ use provider::{ManagedApp, ProcessSpec};
 /// Dedicated tmux socket name — isolates coulson sessions from user's own tmux.
 const TMUX_SOCKET: &str = "coulson";
 
+/// A single log line emitted by a managed process.
+#[derive(Clone, Debug)]
+pub struct LogLine {
+    pub app_id: i64,
+    pub process_type: String,
+    pub line: String,
+}
+
 pub type ProcessManagerHandle = Arc<tokio::sync::Mutex<ProcessManager>>;
 
 pub struct ProcessManagerConfig {
@@ -35,6 +44,7 @@ pub struct ProcessManagerConfig {
     pub backend: ProcessBackend,
     pub hook_manager: Arc<HookManager>,
     pub hook_factory: HookContextFactory,
+    pub log_tx: broadcast::Sender<LogLine>,
 }
 
 pub fn new_process_manager(cfg: ProcessManagerConfig) -> ProcessManagerHandle {
@@ -103,6 +113,7 @@ pub struct ProcessManager {
     use_tmux: bool,
     hook_manager: Arc<HookManager>,
     hook_factory: HookContextFactory,
+    log_tx: broadcast::Sender<LogLine>,
 }
 
 pub enum StartStatus {
@@ -154,6 +165,7 @@ impl ProcessManager {
             use_tmux,
             hook_manager: cfg.hook_manager,
             hook_factory: cfg.hook_factory,
+            log_tx: cfg.log_tx,
         }
     }
 
@@ -168,6 +180,24 @@ impl ProcessManager {
     /// Whether the tmux backend is active.
     pub fn uses_tmux(&self) -> bool {
         self.use_tmux
+    }
+
+    /// List process types for a managed app (e.g. `["web", "worker"]`).
+    pub fn process_types(&self, app_id: i64) -> Vec<String> {
+        let Some(group) = self.processes.get(&app_id) else {
+            return vec![];
+        };
+        let mut types = vec!["web".to_string()];
+        for c in &group.companions {
+            types.push(c.process_type.clone());
+        }
+        types
+    }
+
+    /// Whether log broadcast is available (direct/compose backends).
+    /// Tmux uses `pipe-pane` to file, so no broadcast channel.
+    pub fn has_log_broadcast(&self) -> bool {
+        !self.use_tmux
     }
 
     /// Quick check: is there a live process for this app_id (ready or starting)?
@@ -264,6 +294,8 @@ impl ProcessManager {
 
         cleanup_listen_target(&spec.listen_target);
 
+        let log_tx = &self.log_tx;
+
         let handle = if kind == "docker" {
             // Docker Compose: run `docker compose up -d --build` synchronously,
             // since it exits immediately after starting containers in the background.
@@ -297,8 +329,14 @@ impl ProcessManager {
                 );
             }
 
-            let log_follower =
-                spawn_compose_log_follower(root, &project_name, &compose_file, &log_path);
+            let log_follower = spawn_compose_log_follower(
+                root,
+                &project_name,
+                &compose_file,
+                &log_path,
+                log_tx,
+                app_id,
+            );
 
             ProcessHandle::Compose {
                 project_dir: root.to_path_buf(),
@@ -307,7 +345,7 @@ impl ProcessManager {
                 log_follower,
             }
         } else {
-            self.spawn_process(name, &spec, &log_path, &sockets_dir)?
+            self.spawn_process(name, &spec, &log_path, &sockets_dir, log_tx, app_id, "web")?
         };
 
         // Docker builds can be slow — use a longer readiness timeout.
@@ -333,6 +371,7 @@ impl ProcessManager {
             &manifest,
             env_url_env.as_ref(),
             &log_path,
+            log_tx,
         );
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
@@ -475,6 +514,8 @@ impl ProcessManager {
 
         cleanup_listen_target(&spec.listen_target);
 
+        let log_tx = &self.log_tx;
+
         let handle = if kind == "docker" {
             let project_name = name.to_string();
             let compose_file = spec.args.get(2).cloned().unwrap_or_default();
@@ -505,8 +546,14 @@ impl ProcessManager {
                 );
             }
 
-            let log_follower =
-                spawn_compose_log_follower(root, &project_name, &compose_file, &log_path);
+            let log_follower = spawn_compose_log_follower(
+                root,
+                &project_name,
+                &compose_file,
+                &log_path,
+                log_tx,
+                app_id,
+            );
 
             ProcessHandle::Compose {
                 project_dir: root.to_path_buf(),
@@ -515,7 +562,7 @@ impl ProcessManager {
                 log_follower,
             }
         } else {
-            self.spawn_process(name, &spec, &log_path, &sockets_dir)?
+            self.spawn_process(name, &spec, &log_path, &sockets_dir, log_tx, app_id, "web")?
         };
 
         let companions = self.spawn_companions(
@@ -528,6 +575,7 @@ impl ProcessManager {
             &manifest,
             env_url_env.as_ref(),
             &log_path,
+            log_tx,
         );
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
@@ -721,17 +769,21 @@ impl ProcessManager {
     }
 
     /// Spawn a process using the current backend (direct or tmux).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_process(
         &self,
         name: &str,
         spec: &ProcessSpec,
         log_path: &Path,
         managed_dir: &Path,
+        log_tx: &broadcast::Sender<LogLine>,
+        app_id: i64,
+        process_type: &str,
     ) -> anyhow::Result<ProcessHandle> {
         if self.use_tmux {
             self.spawn_tmux(name, spec, log_path, managed_dir)
         } else {
-            Self::spawn_direct(name, spec, log_path)
+            Self::spawn_direct(name, spec, log_path, log_tx, app_id, process_type)
         }
     }
 
@@ -754,6 +806,7 @@ impl ProcessManager {
         manifest: &Option<serde_json::Value>,
         remote_env: Option<&HashMap<String, String>>,
         primary_log_path: &Path,
+        log_tx: &broadcast::Sender<LogLine>,
     ) -> Vec<CompanionProcess> {
         if companion_types.is_empty() || kind != "procfile" {
             return vec![];
@@ -801,6 +854,9 @@ impl ProcessManager {
                         &spec,
                         &log_path,
                         sockets_dir,
+                        log_tx,
+                        app_id,
+                        ptype,
                     ) {
                         Ok(handle) => {
                             info!(
@@ -837,20 +893,23 @@ impl ProcessManager {
         companions
     }
 
-    /// Spawn via direct child process (original behavior).
+    /// Spawn via direct child process.
+    ///
+    /// stdout/stderr are piped through a tee task that writes to the log file
+    /// and broadcasts each line to `log_tx` for live SSE streaming.
     fn spawn_direct(
         name: &str,
         spec: &ProcessSpec,
         log_path: &Path,
+        log_tx: &broadcast::Sender<LogLine>,
+        app_id: i64,
+        process_type: &str,
     ) -> anyhow::Result<ProcessHandle> {
         let log_file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(log_path)
             .with_context(|| format!("failed to open log file {}", log_path.display()))?;
-        let stderr_file = log_file
-            .try_clone()
-            .with_context(|| "failed to clone log file handle")?;
 
         // All specs go through login shell for user env loading
         let full_cmd = build_full_command(spec);
@@ -871,14 +930,26 @@ impl ProcessManager {
         }
         cmd.process_group(0);
 
-        let child = cmd
+        let mut child = cmd
             .current_dir(&spec.working_dir)
             .kill_on_drop(true)
             .stdin(Stdio::null())
-            .stdout(stderr_file)
-            .stderr(log_file)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .with_context(|| format!("failed to spawn {} for {name}", shell.display()))?;
+
+        // Tee stdout + stderr → log file + broadcast channel
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        spawn_tee_task(
+            stdout,
+            stderr,
+            log_file,
+            log_tx.clone(),
+            app_id,
+            process_type,
+        );
 
         Ok(ProcessHandle::Direct { child })
     }
@@ -947,6 +1018,111 @@ impl ProcessManager {
         debug!(session = %session_name, "spawned tmux session");
 
         Ok(ProcessHandle::Tmux { session_name })
+    }
+}
+
+/// Spawn a background task that reads from stdout + stderr pipes, writes each
+/// line to a log file, and broadcasts it through `log_tx`.
+///
+/// Bytes are split on `\n` manually and decoded with lossy UTF-8 so non-UTF-8
+/// output (terminal escapes, panic traces with binary bytes) does not
+/// terminate the tee. Any trailing bytes not followed by a newline are
+/// flushed on EOF so a crash without a final newline does not swallow the
+/// last message.
+fn spawn_tee_task(
+    stdout: Option<tokio::process::ChildStdout>,
+    stderr: Option<tokio::process::ChildStderr>,
+    log_file: std::fs::File,
+    log_tx: broadcast::Sender<LogLine>,
+    app_id: i64,
+    process_type: &str,
+) {
+    use std::io::Write;
+    use tokio::io::{AsyncRead, AsyncReadExt};
+
+    fn tee_reader<R: AsyncRead + Unpin + Send + 'static>(
+        mut reader: R,
+        log_file: Arc<std::sync::Mutex<std::fs::File>>,
+        log_tx: broadcast::Sender<LogLine>,
+        app_id: i64,
+        process_type: String,
+    ) {
+        tokio::spawn(async move {
+            // Cap how much un-newline-terminated output we will buffer before
+            // forcibly flushing as a synthetic line. Without this a process
+            // that emits a very long single line, a `\r`-driven progress bar,
+            // or a streaming binary blob would grow `pending` unboundedly and
+            // expose Coulson to OOM on noisy child output.
+            const PENDING_CAP: usize = 1024 * 1024;
+
+            let mut buf = [0u8; 4096];
+            let mut pending: Vec<u8> = Vec::with_capacity(512);
+            let emit = |bytes: &[u8],
+                        log_file: &Arc<std::sync::Mutex<std::fs::File>>,
+                        log_tx: &broadcast::Sender<LogLine>,
+                        process_type: &str| {
+                let line = String::from_utf8_lossy(bytes).into_owned();
+                if let Ok(mut f) = log_file.lock() {
+                    let _ = writeln!(f, "{line}");
+                }
+                let _ = log_tx.send(LogLine {
+                    app_id,
+                    process_type: process_type.to_string(),
+                    line,
+                });
+            };
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let mut start = 0;
+                        for (i, b) in buf[..n].iter().enumerate() {
+                            if *b == b'\n' {
+                                let mut chunk = std::mem::take(&mut pending);
+                                chunk.extend_from_slice(&buf[start..i]);
+                                // Strip trailing CR so CRLF output is clean.
+                                if chunk.last() == Some(&b'\r') {
+                                    chunk.pop();
+                                }
+                                emit(&chunk, &log_file, &log_tx, &process_type);
+                                start = i + 1;
+                            }
+                        }
+                        if start < n {
+                            pending.extend_from_slice(&buf[start..n]);
+                        }
+                        // If the buffered fragment is already past the cap,
+                        // flush it now to bound memory. The synthetic line
+                        // may split a "real" line in two, but that is
+                        // strictly better than unbounded growth.
+                        while pending.len() >= PENDING_CAP {
+                            let rest = pending.split_off(PENDING_CAP);
+                            emit(&pending, &log_file, &log_tx, &process_type);
+                            pending = rest;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            // Flush any trailing partial line (no terminating newline) so
+            // crash tails are preserved.
+            if !pending.is_empty() {
+                if pending.last() == Some(&b'\r') {
+                    pending.pop();
+                }
+                emit(&pending, &log_file, &log_tx, &process_type);
+            }
+        });
+    }
+
+    let file = Arc::new(std::sync::Mutex::new(log_file));
+    let ptype = process_type.to_string();
+
+    if let Some(stdout) = stdout {
+        tee_reader(stdout, file.clone(), log_tx.clone(), app_id, ptype.clone());
+    }
+    if let Some(stderr) = stderr {
+        tee_reader(stderr, file, log_tx, app_id, ptype);
     }
 }
 
@@ -1575,12 +1751,15 @@ fn compose_is_running(project_dir: &Path, project_name: &str, compose_file: &str
     }
 }
 
-/// Spawn a `docker compose logs -f` process that continuously writes to a log file.
+/// Spawn a `docker compose logs -f` process that tees output to a log file
+/// and broadcasts lines through `log_tx`.
 fn spawn_compose_log_follower(
     project_dir: &Path,
     project_name: &str,
     compose_file: &str,
     log_path: &Path,
+    log_tx: &broadcast::Sender<LogLine>,
+    app_id: i64,
 ) -> Option<Child> {
     let log_file = match std::fs::OpenOptions::new()
         .create(true)
@@ -1593,13 +1772,6 @@ fn spawn_compose_log_follower(
             return None;
         }
     };
-    let stderr_file = match log_file.try_clone() {
-        Ok(f) => f,
-        Err(e) => {
-            warn!(error = %e, "failed to clone compose log file handle");
-            return None;
-        }
-    };
 
     let mut args = compose_base_args(project_name, compose_file);
     args.extend(["logs", "-f", "--no-color"]);
@@ -1607,13 +1779,16 @@ fn spawn_compose_log_follower(
         .args(&args)
         .current_dir(project_dir)
         .stdin(Stdio::null())
-        .stdout(stderr_file)
-        .stderr(log_file)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
     {
-        Ok(child) => {
+        Ok(mut child) => {
             debug!(project = project_name, "spawned compose log follower");
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            spawn_tee_task(stdout, stderr, log_file, log_tx.clone(), app_id, "web");
             Some(child)
         }
         Err(e) => {
@@ -1812,13 +1987,38 @@ async fn quick_ready_check(target: &ListenTarget) -> bool {
 }
 
 /// Human-readable display of a listen target.
+/// Whether `s` is a safe process_type token.
+///
+/// process_type flows into several sensitive contexts: the log file path
+/// (`{name}-{ptype}.log`), the Procfile lookup key, and URL path segments in
+/// the log streaming endpoints. Restricting it to `[A-Za-z0-9_-]+` (the
+/// de-facto Procfile convention) closes off path-traversal, URL-reserved
+/// characters, and shell metacharacter surprises in one pass.
+pub(crate) fn is_valid_process_type(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// Parse `COULSON_MANAGED_SERVICES` value into companion process types (excluding "web").
 fn parse_managed_services(value: Option<&str>) -> Vec<String> {
     value
         .map(|s| {
             s.split(',')
-                .map(|t| t.trim().to_string())
-                .filter(|t| !t.is_empty() && t != "web")
+                .filter_map(|t| {
+                    let t = t.trim();
+                    if t.is_empty() || t == "web" {
+                        return None;
+                    }
+                    if !is_valid_process_type(t) {
+                        tracing::warn!(
+                            process_type = %t,
+                            "COULSON_MANAGED_SERVICES token rejected: must match [A-Za-z0-9_-]+"
+                        );
+                        return None;
+                    }
+                    Some(t.to_string())
+                })
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
## Summary
- Live log tail page for managed apps over SSE, with tabs per companion process (web / worker / scheduler).
- Cross-app log isolation by comparing normalized file paths, so prefix name collisions never leak another app's log.
- Non-UTF-8 output and crash tails without a final newline are preserved; tee buffer capped at 1 MiB to bound memory.

## Test plan
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test --workspace` — all green (233 tests).
- Manually open log page for a managed app, verify live stream and tab switching update the displayed path.