### PR TITLE
feat(cli): add --version flag via clap

### DIFF
--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -253,7 +253,7 @@ impl SharedState {
 }
 
 #[derive(Parser)]
-#[command(name = "coulson", about = "Local development gateway")]
+#[command(name = "coulson", about = "Local development gateway", version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
- Enable clap's built-in `version` on the root `Cli` so `coulson --version` / `-V` prints the crate version.

## Test plan
- `cargo run -p coulson -- --version`