### PR TITLE
fix(dashboard): log_tail template render error when app has multiple process types

### DIFF
--- a/crates/coulson/src/dashboard/render.rs
+++ b/crates/coulson/src/dashboard/render.rs
@@ -612,9 +612,18 @@ pub fn render_page(
     ctx.insert("title", "Coulson");
     ctx.insert("active_nav", "");
     customize(&mut ctx);
-    templates()
-        .render(template, &ctx)
-        .unwrap_or_else(|e| format!("<html><body><pre>Template error: {e}</pre></body></html>"))
+    templates().render(template, &ctx).unwrap_or_else(|e| {
+        let mut chain = format!("{e}");
+        let mut src: Option<&dyn std::error::Error> = std::error::Error::source(&e);
+        while let Some(cause) = src {
+            chain.push_str(&format!("\nCaused by: {cause}"));
+            src = cause.source();
+        }
+        tracing::error!(template = template, error = %chain, "template render failed");
+        format!(
+            "<html><body><pre>Template error rendering {template}:\n{chain}</pre></body></html>"
+        )
+    })
 }
 
 pub fn render_not_found(state: &SharedState) -> String {

--- a/crates/coulson/src/dashboard/templates/pages/log_tail.html
+++ b/crates/coulson/src/dashboard/templates/pages/log_tail.html
@@ -186,10 +186,10 @@
   }
 
   // Event-delegated tab switching. Using data-process + addEventListener
-  // (rather than inline onclick="switchProcess('{{ pt }}', ...)") keeps
-  // the process_type value out of any JS string context, so a malformed
-  // name like `worker');alert(1);//` cannot break out of an onclick
-  // attribute. Active/inactive class strings are captured from whatever
+  // (rather than inline onclick attributes with the process_type
+  // interpolated into a JS string) keeps the value out of any JS string
+  // context, so a malformed name like `worker');alert(1);//` cannot
+  // break out of an onclick attribute. Active/inactive class strings are captured from whatever
   // the template rendered, so the same handler works in both the
   // embedded (text-xs) and standalone (text-sm) modes without hardcoding
   // a size-specific class list.


### PR DESCRIPTION
## Summary
- Remove the `'{{ pt }}'` literal from a JS comment in `log_tail.html`. Tera does not honor JS comment syntax and tried to resolve `pt` outside the `{% for pt in process_types %}` loop, failing with `Variable 'pt' not found` whenever the multi-tab block was rendered.
- Surface the full Tera error chain (via `source()`) in the `render_page` fallback HTML and in tracing, so future template errors expose the root cause instead of just `Failed to render '<name>'`.

## Test plan
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Verified end-to-end on a deployed instance: multi-process app log tail page now renders; previously failed with the generic Tera message.