### PR TITLE
feat(dashboard): render ANSI colors in log tail with theme-aware palette

### DIFF
--- a/crates/coulson/src/dashboard/templates/pages/log_tail.html
+++ b/crates/coulson/src/dashboard/templates/pages/log_tail.html
@@ -74,6 +74,22 @@
   100%    { border-left-color: transparent; }
 }
 .log-line-new { animation: coulsonLogAccent 2.5s ease-out forwards; }
+/* Light-mode palette: darker shades so colored text reads on bg-white. */
+:root {
+  --ansi-30: #27272a; --ansi-31: #dc2626; --ansi-32: #059669; --ansi-33: #b45309;
+  --ansi-34: #2563eb; --ansi-35: #c026d3; --ansi-36: #0891b2; --ansi-37: #71717a;
+  --ansi-90: #52525b; --ansi-91: #ef4444; --ansi-92: #10b981; --ansi-93: #d97706;
+  --ansi-94: #3b82f6; --ansi-95: #d946ef; --ansi-96: #06b6d4; --ansi-97: #a1a1aa;
+}
+/* Dark-mode palette: lighter shades so colored text reads on bg-zinc-900. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ansi-30: #71717a; --ansi-31: #f87171; --ansi-32: #34d399; --ansi-33: #fbbf24;
+    --ansi-34: #60a5fa; --ansi-35: #e879f9; --ansi-36: #22d3ee; --ansi-37: #d4d4d8;
+    --ansi-90: #a1a1aa; --ansi-91: #fca5a5; --ansi-92: #6ee7b7; --ansi-93: #fcd34d;
+    --ansi-94: #93c5fd; --ansi-95: #f0abfc; --ansi-96: #67e8f9; --ansi-97: #e4e4e7;
+  }
+}
 </style>
 
 <div id="log-stream-config" class="hidden" data-base-path="{{ base }}" data-initial-process="{{ initial_process | default(value='web') }}" data-process-paths="{{ process_log_paths | default(value='{}') | json_encode }}"></div>
@@ -128,6 +144,71 @@
     }
   }
 
+  // ANSI SGR → HTML. Escapes its input so the only tags in the output
+  // are the <span>s this function emits — safe to assign via innerHTML.
+  // Covers the subset emitted by tracing-subscriber and most CLI tools:
+  // reset (0), bold/dim/italic/underline (1/2/3/4) and their resets
+  // (22/23/24), 8 basic fg colors (30-37), bright fg (90-97), and
+  // default fg (39). Unknown codes are dropped rather than echoed.
+  // Refs to CSS variables defined in the page <style> block; each variable
+  // has a light- and dark-mode value via prefers-color-scheme, so colored
+  // output stays readable against both bg-white and bg-zinc-900.
+  var ANSI_COLORS = {
+    30: 'var(--ansi-30)', 31: 'var(--ansi-31)', 32: 'var(--ansi-32)', 33: 'var(--ansi-33)',
+    34: 'var(--ansi-34)', 35: 'var(--ansi-35)', 36: 'var(--ansi-36)', 37: 'var(--ansi-37)',
+    90: 'var(--ansi-90)', 91: 'var(--ansi-91)', 92: 'var(--ansi-92)', 93: 'var(--ansi-93)',
+    94: 'var(--ansi-94)', 95: 'var(--ansi-95)', 96: 'var(--ansi-96)', 97: 'var(--ansi-97)'
+  };
+  function escapeHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+  function ansiToHtml(text) {
+    var re = /\x1b\[([0-9;]*)m/g;
+    var out = '';
+    var last = 0;
+    var state = { color: null, bold: false, dim: false, italic: false, underline: false };
+    function openSpan() {
+      var styles = [];
+      if (state.color) styles.push('color:' + state.color);
+      if (state.bold) styles.push('font-weight:bold');
+      if (state.dim) styles.push('opacity:0.6');
+      if (state.italic) styles.push('font-style:italic');
+      if (state.underline) styles.push('text-decoration:underline');
+      return styles.length ? '<span style="' + styles.join(';') + '">' : '';
+    }
+    var spanOpen = false;
+    function flush(plain) {
+      if (!plain) return;
+      if (spanOpen) { out += '</span>'; spanOpen = false; }
+      var open = openSpan();
+      if (open) { out += open; spanOpen = true; }
+      out += escapeHtml(plain);
+    }
+    var m;
+    while ((m = re.exec(text)) !== null) {
+      flush(text.slice(last, m.index));
+      last = re.lastIndex;
+      var codes = m[1].split(';').filter(function(x) { return x !== ''; }).map(Number);
+      if (codes.length === 0) codes = [0];
+      for (var i = 0; i < codes.length; i++) {
+        var c = codes[i];
+        if (c === 0) { state = { color: null, bold: false, dim: false, italic: false, underline: false }; }
+        else if (c === 1) state.bold = true;
+        else if (c === 2) state.dim = true;
+        else if (c === 3) state.italic = true;
+        else if (c === 4) state.underline = true;
+        else if (c === 22) { state.bold = false; state.dim = false; }
+        else if (c === 23) state.italic = false;
+        else if (c === 24) state.underline = false;
+        else if (c === 39) state.color = null;
+        else if (ANSI_COLORS[c]) state.color = ANSI_COLORS[c];
+      }
+    }
+    flush(text.slice(last));
+    if (spanOpen) { out += '</span>'; spanOpen = false; }
+    return out;
+  }
+
   function appendLogEntry(text, animate) {
     var shouldStick = autoScroll || isNearBottom();
     var entry = document.createElement('pre');
@@ -135,7 +216,7 @@
     clearPlaceholder();
 
     entry.className = logLineClass + (animate ? ' log-line-new' : '');
-    entry.textContent = text;
+    entry.innerHTML = ansiToHtml(text);
     logLines.appendChild(entry);
 
     if (shouldStick) {


### PR DESCRIPTION
## Summary
- Convert ANSI SGR escape sequences to HTML `<span>` in `appendLogEntry` (covers reset, bold/dim/italic/underline, fg 30-37/90-97, default 39; unknown codes dropped).
- Escape log text before injection so only the function's own spans land in `innerHTML`.
- Map colors to CSS variables `--ansi-30..37` / `--ansi-90..97` with light defaults and a `@media (prefers-color-scheme: dark)` override, so colored output stays readable against both `bg-white` and `bg-zinc-900`.

## Test plan
- [x] `cargo test -p coulson dashboard::render` (templates still parse)
- [ ] Manual: open `/_coulson/logs` in both light and dark OS themes, confirm ANSI-colored log lines render with readable contrast.