### PR TITLE
chore(ci): limit push trigger to master to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Feature-branch pushes currently fire both `push` and `pull_request` events, producing two identical CI runs per commit on any branch with an open PR.
- Restrict `push` to the `master` branch. PRs still run via `pull_request`; direct commits/merges on master still run via `push`.

## Test plan
- [ ] Open/update this PR — confirm only `CI / Test` runs once (no `(push)` duplicate).
- [ ] After merge, confirm master still runs CI on push.