### PR TITLE
refactor(process): per-app runtime dir with process-type log/socket names

### DIFF
--- a/CoulsonApp/Sources/CoulsonApp.swift
+++ b/CoulsonApp/Sources/CoulsonApp.swift
@@ -326,12 +326,13 @@ extension AppDelegate {
         guard let box = sender.representedObject as? AppRecordBox else { return }
         Task { @MainActor in
             guard let vm = self.vm else { return }
-            let dir = (vm.runtimeDir as NSString).appendingPathComponent("managed")
-            let logPath = (dir as NSString).appendingPathComponent("\(box.app.name).log")
+            let managedDir = (vm.runtimeDir as NSString).appendingPathComponent("managed")
+            let appDir = (managedDir as NSString).appendingPathComponent(box.app.name)
+            let logPath = (appDir as NSString).appendingPathComponent("web.log")
             if FileManager.default.fileExists(atPath: logPath) {
-                NSWorkspace.shared.selectFile(logPath, inFileViewerRootedAtPath: dir)
-            } else if FileManager.default.fileExists(atPath: dir) {
-                NSWorkspace.shared.open(URL(fileURLWithPath: dir))
+                NSWorkspace.shared.selectFile(logPath, inFileViewerRootedAtPath: appDir)
+            } else if FileManager.default.fileExists(atPath: appDir) {
+                NSWorkspace.shared.open(URL(fileURLWithPath: appDir))
             }
         }
     }

--- a/CoulsonApp/Sources/Views/AppDetailView.swift
+++ b/CoulsonApp/Sources/Views/AppDetailView.swift
@@ -180,7 +180,7 @@ struct AppDetailView: View {
                 }
                 if app.target.type == "managed" {
                     Divider().padding(.leading, 12)
-                    pathRow("Log", (vm.runtimeDir as NSString).appendingPathComponent("managed/\(app.name).log"))
+                    pathRow("Log", (vm.runtimeDir as NSString).appendingPathComponent("managed/\(app.name)/web.log"))
                 }
             }
             .background(.quaternary.opacity(0.3))

--- a/CoulsonApp/Sources/Views/MenuPanel.swift
+++ b/CoulsonApp/Sources/Views/MenuPanel.swift
@@ -217,7 +217,7 @@ enum MenuBuilder {
         sub.addItem(lan)
 
         // Logs (only when log file exists)
-        let logPath = (vm.runtimeDir as NSString).appendingPathComponent("managed/\(app.name).log")
+        let logPath = (vm.runtimeDir as NSString).appendingPathComponent("managed/\(app.name)/web.log")
         if FileManager.default.fileExists(atPath: logPath) {
             sub.addItem(.separator())
 

--- a/crates/coulson/src/dashboard/handlers.rs
+++ b/crates/coulson/src/dashboard/handlers.rs
@@ -63,86 +63,6 @@ fn read_log_tail_lines(log_path: &std::path::Path, max_lines: usize) -> Option<V
     Some(lines[start..].to_vec())
 }
 
-/// Lexically normalize a path: collapse `.` / `..` / redundant separators
-/// WITHOUT touching the filesystem.
-///
-/// Needed because companion-log collision detection must work even when the
-/// log files do not yet exist (e.g. the companion process has never been
-/// spawned). `std::fs::canonicalize` requires the target to exist, so it is
-/// unsuitable here. Lexical normalization is also deliberately unaware of
-/// symlinks — two different symlinks to the same inode will compare unequal,
-/// which is the safer default for config-level collision detection.
-fn lexical_normalize(p: &std::path::Path) -> std::path::PathBuf {
-    use std::path::{Component, PathBuf};
-    let mut out = PathBuf::new();
-    for comp in p.components() {
-        match comp {
-            Component::Prefix(_) | Component::RootDir => out.push(comp.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => match out.components().next_back() {
-                // Collapse against the preceding real segment.
-                Some(Component::Normal(_)) => {
-                    out.pop();
-                }
-                // On an absolute path `/..` equals `/` — drop the extra
-                // ParentDir entirely instead of keeping it as `/../…`,
-                // otherwise two spellings of the same real file would
-                // normalize to different `PathBuf`s and escape
-                // `companion_log_collides`.
-                Some(Component::RootDir) | Some(Component::Prefix(_)) => {}
-                // Relative path with no preceding `Normal` (either empty
-                // or already a `..` chain): preserve the `..` so the
-                // meaning of the relative path is kept.
-                _ => {
-                    out.push("..");
-                }
-            },
-            Component::Normal(s) => out.push(s),
-        }
-    }
-    out
-}
-
-/// Collect lexically-normalized web log paths for every managed app OTHER
-/// than `self_name`.
-///
-/// Used to detect file-path level collisions between a would-be companion
-/// log (`{self}-{ptype}.log`) and some unrelated app's web log. Iterating
-/// the full managed-app set is required because any app — regardless of
-/// name — can point its manifest `log_path` at the same file. Returns
-/// Err on store failure; callers should fail closed.
-fn other_managed_web_log_paths(
-    shared: &SharedState,
-    self_name: &str,
-) -> anyhow::Result<std::collections::HashSet<std::path::PathBuf>> {
-    let sockets_dir = shared.runtime_dir.join("managed");
-    let mut out = std::collections::HashSet::new();
-    for app in shared.store.list_all()? {
-        if app.name == self_name {
-            continue;
-        }
-        let crate::domain::BackendTarget::Managed { root, .. } = &app.target else {
-            continue;
-        };
-        let root_path = std::path::PathBuf::from(root);
-        let manifest = crate::process::load_coulson_toml_manifest(&root_path);
-        let web_log =
-            crate::process::resolve_log_path(&manifest, &root_path, &sockets_dir, &app.name);
-        out.insert(lexical_normalize(&web_log));
-    }
-    Ok(out)
-}
-
-/// Whether `companion_path` would read some other managed app's web log
-/// file. Pure set-membership on normalized paths — compute the set via
-/// [`other_managed_web_log_paths`] once per request and reuse it.
-fn companion_log_collides(
-    other_paths: &std::collections::HashSet<std::path::PathBuf>,
-    companion_path: &std::path::Path,
-) -> bool {
-    other_paths.contains(&lexical_normalize(companion_path))
-}
-
 pub async fn favicon() -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -670,15 +590,16 @@ pub async fn page_process_log(
         Ok(Some(app)) => app,
         _ => return html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared)),
     };
-    let sockets_dir = state.shared.runtime_dir.join("managed");
-    let log_path = match &app.target {
+    let app_dir = state.shared.runtime_dir.join("managed").join(&app.name);
+    let log_dir = match &app.target {
         crate::domain::BackendTarget::Managed { root, .. } => {
             let root = std::path::Path::new(root);
             let manifest = crate::process::load_coulson_toml_manifest(root);
-            crate::process::resolve_log_path(&manifest, root, &sockets_dir, &app.name)
+            crate::process::resolve_log_dir(&manifest, root, &app_dir)
         }
-        _ => sockets_dir.join(format!("{}.log", app.name)),
+        _ => app_dir,
     };
+    let log_path = crate::process::process_log_path(&log_dir, "web");
     let log_content = read_log_tail_lines(&log_path, 200).map(|lines| lines.join("\n"));
     let page = render_page("pages/process_log.html", &state.shared, |ctx| {
         ctx.insert("title", &format!("{} — Log", app.name));
@@ -1145,75 +1066,29 @@ pub async fn page_logs(
         }
     };
 
-    let sockets_dir = state.shared.runtime_dir.join("managed");
     let manifest = crate::process::load_coulson_toml_manifest(&root);
-    let log_path = crate::process::resolve_log_path(&manifest, &root, &sockets_dir, &app.name);
+    let app_dir = state.shared.runtime_dir.join("managed").join(&app.name);
+    let log_dir = crate::process::resolve_log_dir(&manifest, &root, &app_dir);
 
     let runtime_types = {
         let pm = state.shared.process_manager.lock().await;
         pm.process_types(app.id.0)
     };
 
-    // Determine whether a companion log candidate would actually share a
-    // file path with some OTHER app's resolved web log. Scan every managed
-    // app (not just `{name}-{ptype}`) because any app, regardless of name,
-    // can point its manifest `log_path` at the same file. Fail closed on
-    // store error so a transient DB hiccup never exposes another app's log.
-    let log_dir = log_path.parent().unwrap_or(&sockets_dir);
-    let other_paths = match other_managed_web_log_paths(&state.shared, &app.name) {
-        Ok(set) => Some(set),
-        Err(e) => {
-            tracing::warn!(error = %e, app = %app.name, "store lookup failed; hiding all companion log tabs");
-            None
-        }
-    };
-    let collides = |ptype: &str| -> bool {
-        if ptype == "web" {
-            return false;
-        }
-        let stem = format!("{}-{}", app.name, ptype);
-        let companion_path = log_dir.join(format!("{stem}.log"));
-        match &other_paths {
-            Some(set) => companion_log_collides(set, &companion_path),
-            None => true,
-        }
-    };
-
-    // Filter runtime types so the page and the SSE endpoint agree on
-    // which companions are reachable. Without this, a genuinely-colliding
-    // companion would appear as a tab here but 404 when clicked.
-    let runtime_types: Vec<String> = runtime_types.into_iter().filter(|t| !collides(t)).collect();
-
-    // Scan the log directory for any companion log files
-    // (`{name}.log`, `{name}-{ptype}.log`) so we can offer switchers for
-    // worker/scheduler/etc. even if the process is not currently running.
-    // Skip any candidate whose file path would actually overlap with
-    // another registered app's web log — `foo-worker.log` (the web log of
-    // `foo-worker`) would otherwise be misread as `foo`'s `worker`
-    // companion when both apps share `{sockets_dir}` as their log dir.
+    // Scan the app's log directory for `{ptype}.log` files so we can offer
+    // switchers for worker/scheduler/etc. even when the process is not
+    // currently running. Each app owns its log directory, so a `*.log` stem
+    // is directly the process type — no app-name prefix to strip and no way
+    // to read an unrelated app's log.
     let mut disk_types: Vec<String> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(log_dir) {
+    if let Ok(entries) = std::fs::read_dir(&log_dir) {
         for entry in entries.flatten() {
             let fname_os = entry.file_name();
             let Some(fname) = fname_os.to_str() else {
                 continue;
             };
-            if fname == format!("{}.log", app.name) {
-                disk_types.push("web".to_string());
-            } else if let Some(rest) = fname.strip_prefix(&format!("{}-", app.name)) {
-                if let Some(ptype) = rest.strip_suffix(".log") {
-                    // Skip files whose inferred `ptype` does not match the
-                    // process_type charset. Without this a legit log like
-                    // `foo-bar.baz.log` (left by some unrelated tool or
-                    // historical data) would surface as a `bar.baz` tab that
-                    // `sse_logs` would then reject anyway — an avoidable
-                    // "tab shown then 404" inconsistency.
-                    if !crate::process::is_valid_process_type(ptype) {
-                        continue;
-                    }
-                    if collides(ptype) {
-                        continue;
-                    }
+            if let Some(ptype) = fname.strip_suffix(".log") {
+                if crate::process::is_valid_process_type(ptype) {
                     disk_types.push(ptype.to_string());
                 }
             }
@@ -1236,18 +1111,12 @@ pub async fn page_logs(
         }
     }
 
-    // Map each process_type to its on-disk log path so the UI can update
-    // the displayed filename when the user switches tabs — the primary
-    // `log_path` only describes the `web` log, while companions live at
-    // `{log_dir}/{name}-{ptype}.log` (matching `spawn_tee_task`'s target).
+    // Map each process_type to its on-disk log path (`{log_dir}/{ptype}.log`)
+    // so the UI can show the filename when the user switches tabs.
     let mut process_log_paths: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
     for pt in &process_types {
-        let p = if pt == "web" {
-            log_path.clone()
-        } else {
-            log_dir.join(format!("{}-{}.log", app.name, pt))
-        };
+        let p = crate::process::process_log_path(&log_dir, pt);
         process_log_paths.insert(pt.clone(), p.to_string_lossy().into_owned());
     }
     let initial_process = process_types
@@ -1257,7 +1126,11 @@ pub async fn page_logs(
     let initial_log_path = process_log_paths
         .get(&initial_process)
         .cloned()
-        .unwrap_or_else(|| log_path.to_string_lossy().into_owned());
+        .unwrap_or_else(|| {
+            crate::process::process_log_path(&log_dir, "web")
+                .to_string_lossy()
+                .into_owned()
+        });
 
     let page = render_page("pages/log_tail.html", &state.shared, |ctx| {
         ctx.insert("title", &format!("{} — Logs", app.name));
@@ -1291,10 +1164,10 @@ pub async fn sse_logs(
         _ => return html_response(StatusCode::NOT_FOUND, "Not found".to_string()),
     };
 
-    // Reject process_types that would escape the `{name}-{ptype}.log`
-    // filename into a nested path or non-ASCII filesystem segment. "web"
-    // is the only companion-less case that bypasses the log-name format,
-    // so it is always admitted even though it also matches the charset.
+    // Reject process_types that would escape the `{ptype}.log` filename into a
+    // nested path or non-ASCII filesystem segment. "web" is the only
+    // companion-less case that bypasses the format, so it is always admitted
+    // even though it also matches the charset.
     if process_type != "web" && !crate::process::is_valid_process_type(&process_type) {
         return html_response(StatusCode::NOT_FOUND, "Not found".to_string());
     }
@@ -1305,9 +1178,9 @@ pub async fn sse_logs(
         .and_then(|v| v.to_str().ok())
         .is_some_and(|v| v.contains("text/event-stream"));
 
-    // Resolve the log file path for this process_type. The web log follows
-    // the manifest's log_path; companion logs live in the same directory as
-    // `{name}-{ptype}.log`.
+    // Resolve the log file for this process_type: `{log_dir}/{ptype}.log`.
+    // The app owns its log directory, so there is no way to read another
+    // app's log here.
     let root = match &app.target {
         crate::domain::BackendTarget::Managed { root, .. } => std::path::PathBuf::from(root),
         _ => {
@@ -1319,35 +1192,10 @@ pub async fn sse_logs(
             return plain_text_stream(futures::stream::pending::<String>());
         }
     };
-    let sockets_dir = state.shared.runtime_dir.join("managed");
     let manifest = crate::process::load_coulson_toml_manifest(&root);
-    let web_log = crate::process::resolve_log_path(&manifest, &root, &sockets_dir, &app.name);
-    // Refuse companion process_types whose resolved log path would actually
-    // overlap another registered app's web log. Compare resolved paths (not
-    // just names) so a `foo-worker` app with a manifest `log_path` pointing
-    // elsewhere does not block `foo`'s legitimate `worker` companion. Fail
-    // closed on store error: we would rather 404 than leak another app's
-    // log during a transient DB hiccup.
-    let log_path = if process_type == "web" {
-        web_log.clone()
-    } else {
-        web_log
-            .parent()
-            .unwrap_or(&sockets_dir)
-            .join(format!("{}-{}.log", app.name, process_type))
-    };
-    if process_type != "web" {
-        let collides = match other_managed_web_log_paths(&state.shared, &app.name) {
-            Ok(set) => companion_log_collides(&set, &log_path),
-            Err(e) => {
-                tracing::warn!(error = %e, app = %app.name, "store lookup failed; refusing companion log stream");
-                true
-            }
-        };
-        if collides {
-            return html_response(StatusCode::NOT_FOUND, "Not found".to_string());
-        }
-    }
+    let app_dir = state.shared.runtime_dir.join("managed").join(&app.name);
+    let log_dir = crate::process::resolve_log_dir(&manifest, &root, &app_dir);
+    let log_path = crate::process::process_log_path(&log_dir, &process_type);
 
     let has_broadcast = {
         let pm = state.shared.process_manager.lock().await;
@@ -1561,51 +1409,4 @@ pub async fn not_found(
         );
     }
     html_response(StatusCode::NOT_FOUND, render_not_found(&state.shared))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::lexical_normalize;
-    use std::path::{Path, PathBuf};
-
-    fn norm(p: &str) -> PathBuf {
-        lexical_normalize(Path::new(p))
-    }
-
-    #[test]
-    fn normalizes_curdir_and_simple_parent() {
-        assert_eq!(norm("./logs/../foo.log"), PathBuf::from("foo.log"));
-        assert_eq!(norm("a/b/../c"), PathBuf::from("a/c"));
-    }
-
-    #[test]
-    fn preserves_relative_parent_chain() {
-        assert_eq!(norm("../foo"), PathBuf::from("../foo"));
-        assert_eq!(norm("../../foo/bar"), PathBuf::from("../../foo/bar"));
-    }
-
-    #[test]
-    fn collapses_extra_parents_above_root() {
-        // `/..` is `/` on Unix — extra ParentDir above RootDir must not
-        // survive into the normalized path, otherwise two spellings of
-        // the same real file compare unequal.
-        assert_eq!(
-            norm("/tmp/../../tmp/foo.log"),
-            PathBuf::from("/tmp/foo.log")
-        );
-        assert_eq!(norm("/.."), PathBuf::from("/"));
-        assert_eq!(norm("/../.."), PathBuf::from("/"));
-    }
-
-    #[test]
-    fn strips_trailing_separator() {
-        assert_eq!(norm("a/b/"), PathBuf::from("a/b"));
-        assert_eq!(norm("/tmp/"), PathBuf::from("/tmp"));
-    }
-
-    #[test]
-    fn absolute_and_root_edge_cases() {
-        assert_eq!(norm("/"), PathBuf::from("/"));
-        assert_eq!(norm("/tmp/foo.log"), PathBuf::from("/tmp/foo.log"));
-    }
 }

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -2385,15 +2385,16 @@ fn run_logs(
         }
     };
 
-    let sockets_dir = daemon_runtime_dir(&cfg).join("managed");
-    let log_path = match app_root {
+    let app_dir = daemon_runtime_dir(&cfg).join("managed").join(&bare_name);
+    let log_dir = match app_root {
         Some(ref root) => {
             let root = std::path::Path::new(root);
             let manifest = crate::process::load_coulson_toml_manifest(root);
-            crate::process::resolve_log_path(&manifest, root, &sockets_dir, &bare_name)
+            crate::process::resolve_log_dir(&manifest, root, &app_dir)
         }
-        None => sockets_dir.join(format!("{bare_name}.log")),
+        None => app_dir,
     };
+    let log_path = crate::process::process_log_path(&log_dir, "web");
 
     if path {
         println!("{}", log_path.display());

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -270,17 +270,16 @@ impl ProcessManager {
             cleanup_listen_target(&removed.primary.listen_target);
         }
 
-        let (mut spec, sockets_dir, prov_name, companion_types, manifest) =
+        let (mut spec, app_dir, prov_name, companion_types, manifest) =
             self.resolve_spec(app_id, name, root, kind)?;
 
         if let Some(remote_env) = env_url_env.as_ref() {
             merge_remote_env(&mut spec, remote_env.clone(), &manifest);
         }
 
-        let log_path = resolve_log_path(&manifest, root, &sockets_dir, name);
-        if let Some(parent) = log_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
+        let log_dir = resolve_log_dir(&manifest, root, &app_dir);
+        std::fs::create_dir_all(&log_dir).ok();
+        let log_path = process_log_path(&log_dir, "web");
 
         info!(
             app_id,
@@ -345,7 +344,7 @@ impl ProcessManager {
                 log_follower,
             }
         } else {
-            self.spawn_process(name, &spec, &log_path, &sockets_dir, log_tx, app_id, "web")?
+            self.spawn_process(name, &spec, &log_path, &app_dir, log_tx, app_id, "web")?
         };
 
         // Docker builds can be slow — use a longer readiness timeout.
@@ -367,10 +366,10 @@ impl ProcessManager {
             root,
             kind,
             &companion_types,
-            &sockets_dir,
+            &app_dir,
             &manifest,
             env_url_env.as_ref(),
-            &log_path,
+            &log_dir,
             log_tx,
         );
 
@@ -469,8 +468,9 @@ impl ProcessManager {
                     kill_handle(companion.handle).await;
                 }
                 let manifest = load_coulson_toml_manifest(root);
-                let fallback_dir = self.runtime_dir.join("managed");
-                let timed_out_log = resolve_log_path(&manifest, root, &fallback_dir, name);
+                let app_dir = self.runtime_dir.join("managed").join(name);
+                let log_dir = resolve_log_dir(&manifest, root, &app_dir);
+                let timed_out_log = process_log_path(&log_dir, "web");
                 log_tail(&timed_out_log, name);
                 kill_handle(removed.primary.handle).await;
                 cleanup_listen_target(&removed.primary.listen_target);
@@ -490,17 +490,16 @@ impl ProcessManager {
             None => {} // No existing process, proceed to spawn
         }
 
-        let (mut spec, sockets_dir, prov_name, companion_types, manifest) =
+        let (mut spec, app_dir, prov_name, companion_types, manifest) =
             self.resolve_spec(app_id, name, root, kind)?;
 
         if let Some(remote_env) = env_url_env.as_ref() {
             merge_remote_env(&mut spec, remote_env.clone(), &manifest);
         }
 
-        let log_path = resolve_log_path(&manifest, root, &sockets_dir, name);
-        if let Some(parent) = log_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
+        let log_dir = resolve_log_dir(&manifest, root, &app_dir);
+        std::fs::create_dir_all(&log_dir).ok();
+        let log_path = process_log_path(&log_dir, "web");
 
         info!(
             app_id,
@@ -562,7 +561,7 @@ impl ProcessManager {
                 log_follower,
             }
         } else {
-            self.spawn_process(name, &spec, &log_path, &sockets_dir, log_tx, app_id, "web")?
+            self.spawn_process(name, &spec, &log_path, &app_dir, log_tx, app_id, "web")?
         };
 
         let companions = self.spawn_companions(
@@ -571,10 +570,10 @@ impl ProcessManager {
             root,
             kind,
             &companion_types,
-            &sockets_dir,
+            &app_dir,
             &manifest,
             env_url_env.as_ref(),
-            &log_path,
+            &log_dir,
             log_tx,
         );
 
@@ -698,8 +697,9 @@ impl ProcessManager {
     }
 
     /// Resolve a ProcessSpec from the provider registry.
-    /// Returns the spec, sockets directory, provider name, companion types,
-    /// and the loaded `.coulson.toml` manifest (if any) for env re-application.
+    /// Returns the spec, the per-app runtime directory (`$RUNTIME/managed/{name}/`),
+    /// provider name, companion types, and the loaded `.coulson.toml` manifest
+    /// (if any) for env re-application.
     #[allow(clippy::type_complexity)]
     fn resolve_spec(
         &self,
@@ -719,10 +719,15 @@ impl ProcessManager {
             .get(kind)
             .ok_or_else(|| anyhow::anyhow!("no process provider for kind: {kind}"))?;
 
-        let managed_dir = self.runtime_dir.join("managed");
-        std::fs::create_dir_all(&managed_dir)
-            .with_context(|| format!("failed to create {}", managed_dir.display()))?;
-        let sockets_dir = std::fs::canonicalize(&managed_dir).unwrap_or(managed_dir);
+        // Each app gets its own runtime directory `$RUNTIME/managed/{name}/`.
+        // The app name lives in the directory, so socket/log files inside are
+        // named purely by process type (`web.sock`, `web.log`, `worker.log`),
+        // which also makes cross-app filename collisions structurally
+        // impossible.
+        let app_dir = self.runtime_dir.join("managed").join(name);
+        std::fs::create_dir_all(&app_dir)
+            .with_context(|| format!("failed to create {}", app_dir.display()))?;
+        let app_dir = std::fs::canonicalize(&app_dir).unwrap_or(app_dir);
 
         let env_overrides = crate::process::provider::load_coulsonrc(root);
 
@@ -748,7 +753,7 @@ impl ProcessManager {
             kind: kind.to_string(),
             manifest,
             env_overrides,
-            socket_dir: sockets_dir.clone(),
+            socket_dir: app_dir.clone(),
         };
 
         let mut spec = prov.resolve(&managed_app)?;
@@ -761,7 +766,7 @@ impl ProcessManager {
         let _ = app_id; // used in caller for logging
         Ok((
             spec,
-            sockets_dir,
+            app_dir,
             prov.display_name().to_string(),
             companion_types,
             managed_app.manifest,
@@ -781,7 +786,7 @@ impl ProcessManager {
         process_type: &str,
     ) -> anyhow::Result<ProcessHandle> {
         if self.use_tmux {
-            self.spawn_tmux(name, spec, log_path, managed_dir)
+            self.spawn_tmux(name, spec, log_path, managed_dir, process_type)
         } else {
             Self::spawn_direct(name, spec, log_path, log_tx, app_id, process_type)
         }
@@ -802,10 +807,10 @@ impl ProcessManager {
         root: &Path,
         kind: &str,
         companion_types: &[String],
-        sockets_dir: &Path,
+        app_dir: &Path,
         manifest: &Option<serde_json::Value>,
         remote_env: Option<&HashMap<String, String>>,
-        primary_log_path: &Path,
+        log_dir: &Path,
         log_tx: &broadcast::Sender<LogLine>,
     ) -> Vec<CompanionProcess> {
         if companion_types.is_empty() || kind != "procfile" {
@@ -819,7 +824,7 @@ impl ProcessManager {
             kind: kind.to_string(),
             manifest: manifest.clone(),
             env_overrides,
-            socket_dir: sockets_dir.to_path_buf(),
+            socket_dir: app_dir.to_path_buf(),
         };
 
         let provider = procfile::ProcfileProvider;
@@ -845,15 +850,12 @@ impl ProcessManager {
                     } else {
                         apply_manifest_env(&mut spec, manifest);
                     }
-                    let log_path = primary_log_path
-                        .parent()
-                        .unwrap_or(sockets_dir)
-                        .join(format!("{name}-{ptype}.log"));
+                    let log_path = process_log_path(log_dir, ptype);
                     match self.spawn_process(
                         &format!("{name}-{ptype}"),
                         &spec,
                         &log_path,
-                        sockets_dir,
+                        app_dir,
                         log_tx,
                         app_id,
                         ptype,
@@ -960,7 +962,8 @@ impl ProcessManager {
         name: &str,
         spec: &ProcessSpec,
         log_path: &Path,
-        managed_dir: &Path,
+        app_dir: &Path,
+        process_type: &str,
     ) -> anyhow::Result<ProcessHandle> {
         let session_name = name.to_string();
 
@@ -969,8 +972,9 @@ impl ProcessManager {
             tmux_kill_session(&session_name);
         }
 
-        // Generate wrapper script
-        let script_path = managed_dir.join(format!("{name}.sh"));
+        // Generate wrapper script — named by process type within the per-app
+        // directory (the app name is already in `app_dir`).
+        let script_path = app_dir.join(format!("{process_type}.sh"));
         let script_content = generate_wrapper_script(&user_shell(), spec);
         std::fs::write(&script_path, &script_content)
             .with_context(|| format!("failed to write wrapper script {}", script_path.display()))?;
@@ -1127,30 +1131,60 @@ fn spawn_tee_task(
 }
 
 /// Extract `idle_timeout_secs` from a `.coulson.toml` manifest JSON value.
-/// Resolve the effective log file path for a managed app.
+/// Resolve the directory where a managed app's process logs live.
 ///
-/// If the manifest specifies a `log_path`, resolve it (relative paths are
-/// joined to the app root). Otherwise fall back to `{sockets_dir}/{name}.log`.
-pub(crate) fn resolve_log_path(
+/// Each process writes to `{log_dir}/{process_type}.log` (see
+/// [`process_log_path`]). The directory namespaces an app's logs, so the file
+/// names carry only the process type — never the app name.
+///
+/// Priority:
+/// 1. manifest `log_dir` — explicit directory (relative paths join the app root)
+/// 2. manifest `log_path` — **deprecated**; the parent directory of the given
+///    file path is used (a warning is emitted)
+/// 3. default `{app_runtime_dir}` (`$RUNTIME/managed/{name}/`)
+pub(crate) fn resolve_log_dir(
     manifest: &Option<serde_json::Value>,
     root: &Path,
-    sockets_dir: &Path,
-    name: &str,
+    app_runtime_dir: &Path,
 ) -> PathBuf {
-    if let Some(raw) = manifest
-        .as_ref()
-        .and_then(|m| m.get("log_path"))
-        .and_then(|v| v.as_str())
-    {
+    let manifest = manifest.as_ref();
+    let resolve_relative = |raw: &str| -> PathBuf {
         let p = Path::new(raw);
         if p.is_absolute() {
             p.to_path_buf()
         } else {
             root.join(p)
         }
-    } else {
-        sockets_dir.join(format!("{name}.log"))
+    };
+
+    if let Some(raw) = manifest
+        .and_then(|m| m.get("log_dir"))
+        .and_then(|v| v.as_str())
+    {
+        return resolve_relative(raw);
     }
+
+    if let Some(raw) = manifest
+        .and_then(|m| m.get("log_path"))
+        .and_then(|v| v.as_str())
+    {
+        warn!(
+            log_path = raw,
+            "`log_path` in .coulson.toml is deprecated; use `log_dir` (a directory). \
+             Treating the parent directory as the log directory."
+        );
+        let p = resolve_relative(raw);
+        return p.parent().map(Path::to_path_buf).unwrap_or(p);
+    }
+
+    app_runtime_dir.to_path_buf()
+}
+
+/// Build the log file path for a single process within an app's log directory.
+/// The app name lives in `log_dir`, so the file is named purely by process type
+/// (`web.log`, `worker.log`, …).
+pub(crate) fn process_log_path(log_dir: &Path, process_type: &str) -> PathBuf {
+    log_dir.join(format!("{process_type}.log"))
 }
 
 fn manifest_idle_timeout(manifest: &Option<serde_json::Value>) -> Option<Duration> {
@@ -1990,7 +2024,7 @@ async fn quick_ready_check(target: &ListenTarget) -> bool {
 /// Whether `s` is a safe process_type token.
 ///
 /// process_type flows into several sensitive contexts: the log file path
-/// (`{name}-{ptype}.log`), the Procfile lookup key, and URL path segments in
+/// (`{ptype}.log`), the Procfile lookup key, and URL path segments in
 /// the log streaming endpoints. Restricting it to `[A-Za-z0-9_-]+` (the
 /// de-facto Procfile convention) closes off path-traversal, URL-reserved
 /// characters, and shell metacharacter surprises in one pass.
@@ -2604,49 +2638,86 @@ OVERRIDE = "toml_wins"
         fs::remove_dir_all(&dir).ok();
     }
 
-    // -- resolve_log_path --
+    // -- resolve_log_dir / process_log_path --
 
     #[test]
-    fn resolve_log_path_falls_back_to_default() {
+    fn resolve_log_dir_falls_back_to_app_runtime_dir() {
         let manifest: Option<serde_json::Value> = None;
         let root = Path::new("/app");
-        let sockets = Path::new("/run/coulson/managed");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
         assert_eq!(
-            resolve_log_path(&manifest, root, sockets, "myapp"),
-            PathBuf::from("/run/coulson/managed/myapp.log")
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/run/coulson/managed/myapp")
         );
     }
 
     #[test]
-    fn resolve_log_path_absolute() {
-        let manifest = Some(serde_json::json!({ "log_path": "/var/log/myapp.log" }));
-        let root = Path::new("/app");
-        let sockets = Path::new("/run/coulson/managed");
-        assert_eq!(
-            resolve_log_path(&manifest, root, sockets, "myapp"),
-            PathBuf::from("/var/log/myapp.log")
-        );
-    }
-
-    #[test]
-    fn resolve_log_path_relative_joins_root() {
-        let manifest = Some(serde_json::json!({ "log_path": "tmp/log/web.log" }));
-        let root = Path::new("/home/user/myapp");
-        let sockets = Path::new("/run/coulson/managed");
-        assert_eq!(
-            resolve_log_path(&manifest, root, sockets, "myapp"),
-            PathBuf::from("/home/user/myapp/tmp/log/web.log")
-        );
-    }
-
-    #[test]
-    fn resolve_log_path_empty_manifest_uses_default() {
+    fn resolve_log_dir_empty_manifest_uses_default() {
         let manifest = Some(serde_json::json!({}));
         let root = Path::new("/app");
-        let sockets = Path::new("/run/coulson/managed");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
         assert_eq!(
-            resolve_log_path(&manifest, root, sockets, "myapp"),
-            PathBuf::from("/run/coulson/managed/myapp.log")
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/run/coulson/managed/myapp")
+        );
+    }
+
+    #[test]
+    fn resolve_log_dir_explicit_absolute() {
+        let manifest = Some(serde_json::json!({ "log_dir": "/var/log/myapp" }));
+        let root = Path::new("/app");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
+        assert_eq!(
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/var/log/myapp")
+        );
+    }
+
+    #[test]
+    fn resolve_log_dir_explicit_relative_joins_root() {
+        let manifest = Some(serde_json::json!({ "log_dir": "logs" }));
+        let root = Path::new("/home/user/myapp");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
+        assert_eq!(
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/home/user/myapp/logs")
+        );
+    }
+
+    #[test]
+    fn resolve_log_dir_deprecated_log_path_uses_parent() {
+        let manifest = Some(serde_json::json!({ "log_path": "logs/web.log" }));
+        let root = Path::new("/home/user/myapp");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
+        // The deprecated single-file `log_path` collapses to its parent dir, so
+        // companions land next to the web log instead of using app-prefixed names.
+        assert_eq!(
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/home/user/myapp/logs")
+        );
+    }
+
+    #[test]
+    fn resolve_log_dir_prefers_log_dir_over_deprecated_log_path() {
+        let manifest = Some(serde_json::json!({ "log_dir": "logs", "log_path": "old/web.log" }));
+        let root = Path::new("/home/user/myapp");
+        let app_dir = Path::new("/run/coulson/managed/myapp");
+        assert_eq!(
+            resolve_log_dir(&manifest, root, app_dir),
+            PathBuf::from("/home/user/myapp/logs")
+        );
+    }
+
+    #[test]
+    fn process_log_path_names_by_process_type() {
+        let log_dir = Path::new("/run/coulson/managed/myapp");
+        assert_eq!(
+            process_log_path(log_dir, "web"),
+            PathBuf::from("/run/coulson/managed/myapp/web.log")
+        );
+        assert_eq!(
+            process_log_path(log_dir, "worker"),
+            PathBuf::from("/run/coulson/managed/myapp/worker.log")
         );
     }
 

--- a/crates/coulson/src/process/provider.rs
+++ b/crates/coulson/src/process/provider.rs
@@ -41,14 +41,17 @@ pub struct ManagedApp {
     pub manifest: Option<Value>,
     /// User-defined environment variable overrides (via control API).
     pub env_overrides: HashMap<String, String>,
-    /// Directory where Unix sockets should be placed.
+    /// Per-app runtime directory where this app's Unix socket and logs live
+    /// (`$RUNTIME/managed/{name}/`). Named `socket_dir` for historical reasons.
     pub socket_dir: PathBuf,
 }
 
 impl ManagedApp {
-    /// Convenience: build the standard socket path for this app.
+    /// Convenience: build the web process socket path for this app. The app
+    /// name is already encoded in `socket_dir` (the per-app directory), so the
+    /// file is named after the process type rather than repeating the name.
     pub fn socket_path(&self) -> PathBuf {
-        self.socket_dir.join(format!("{}.sock", self.name))
+        self.socket_dir.join("web.sock")
     }
 }
 


### PR DESCRIPTION
## Summary
- Give each managed app its own runtime directory `\$COULSON_RUNTIME_DIR/managed/{name}/`; socket and log files inside are named purely by process type (`web.sock`, `web.log`, `worker.log`) since the app name is already in the path.
- Replace the single-file `resolve_log_path` with `resolve_log_dir` + `process_log_path(log_dir, ptype)`. New `.coulson.toml` `log_dir` field (directory); the legacy single-file `log_path` is kept as a deprecated alias (its parent directory is used, with a warning).
- Delete the dashboard cross-app log collision apparatus (`other_managed_web_log_paths`, `companion_log_collides`, `lexical_normalize`): per-app directories make cross-app filename collisions structurally impossible, so the log-tab discovery simplifies to "`*.log` stem = process type".
- Update CLI `coulson logs`, dashboard log readers/streams, tmux wrapper-script naming, and the Swift menu bar app (3 spots that still pointed at the old flat `managed/{name}.log`).

## Test plan
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p coulson` — 230 passed
- Swift app could not be fully compiled here (pre-existing missing Sparkle XCFramework artifact, unrelated); changes are path-string adjustments only.

## Notes
- Migration: on restart the daemon writes to the new per-app paths; old flat `managed/*.sock` / `*.log` files are left orphaned (not auto-removed).