### PR TITLE
feat: layered env resolution (.coulsonrc highest) + coulson env inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "tera",
+ "terminal_size",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -1992,6 +1993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3266,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,6 +3857,16 @@ dependencies = [
  "serde_json",
  "slug",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "capnpc",
  "clap",
  "colored",
+ "dotenvy",
  "futures",
  "h2",
  "hickory-resolver",
@@ -975,6 +976,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.4.0"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+dotenvy = "0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.4.0"
 anyhow = "1"
 async-trait = "0.1"
 dotenvy = "0.15"
+terminal_size = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -195,7 +195,19 @@ PORT=4000
 DATABASE_URL=postgres://localhost/myapp_dev
 ```
 
-When `PORT` is set, the app always starts on that fixed port instead of auto-allocating one. Supports `KEY=VALUE` format with `#` comments, optional quoting, and `export` prefix.
+When `PORT` is set, the app always starts on that fixed port instead of auto-allocating one. Standard dotenv format (parsed by `dotenvy`): `KEY=VALUE`, `#` comments, quoting, `export` prefix, and `${VAR}` interpolation (escape a literal `$` as `\$` or single-quote it).
+
+`${VAR}` interpolation resolves against earlier same-file entries **and the daemon's own environment** — and a matching process-env var takes precedence over a same-file definition. In practice this only matters in development: run the daemon under a service manager (launchd/systemd) and it executes in a clean, minimal environment, so interpolation only sees infrastructure vars. When you start the daemon from an interactive shell, any variable you `export`ed there is visible to `${VAR}` and can shadow a same-file value.
+
+`.coulsonrc` is the **manual, local override** file and has the **highest precedence** — it wins over `.coulson.toml [env]` and `env_url`. The intended split: `.coulson.toml` holds programmatic/provisioned config (committed), while `.coulsonrc` holds hand-edited local overrides (typically gitignored).
+
+**Environment precedence** (lowest → highest):
+
+```
+provider defaults  <  .coulson.toml [env]  <  env_url  <  .coulsonrc
+```
+
+Rationale: committed `[env]` provides defaults/placeholders; `env_url` delivers authoritative remote secrets that override those defaults; `.coulsonrc` is the hand-edited local override that wins over everything (handy for pointing at a local DB while debugging). Below the provider defaults sit the user login-shell rc and the daemon's own environment.
 
 ### `.coulson.toml` — Per-App Configuration
 

--- a/crates/coulson/Cargo.toml
+++ b/crates/coulson/Cargo.toml
@@ -54,6 +54,7 @@ percent-encoding.workspace = true
 procfile.workspace = true
 libc.workspace = true
 keyring.workspace = true
+dotenvy.workspace = true
 
 [features]
 builtin-quick-tunnel = []

--- a/crates/coulson/Cargo.toml
+++ b/crates/coulson/Cargo.toml
@@ -55,6 +55,7 @@ procfile.workspace = true
 libc.workspace = true
 keyring.workspace = true
 dotenvy.workspace = true
+terminal_size.workspace = true
 
 [features]
 builtin-quick-tunnel = []

--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -513,6 +513,24 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
             let infos = pm.list_status();
             Ok(json!({ "processes": infos }))
         }
+        "process.env" => {
+            let params: AppIdParams = parse_params!(req);
+            let app = find_app!(state, req, params.app_id);
+            if !matches!(app.target, crate::domain::BackendTarget::Managed { .. }) {
+                return render_err(
+                    req.request_id,
+                    ControlError::InvalidParams("app is not a managed process".to_string()),
+                );
+            }
+            let mut pm = state.process_manager.lock().await;
+            match pm.process_env(params.app_id) {
+                Some(entries) => Ok(json!({ "env": entries })),
+                None => Err(ControlError::InvalidParams(format!(
+                    "{} is not running; start it (open it or `coulson start`), or use `coulson env --preview`",
+                    app.name
+                ))),
+            }
+        }
         "process.start" | "process.stop" | "process.restart" => {
             let params: AppIdParams = parse_params!(req);
             let app = find_app!(state, req, params.app_id);

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -338,6 +338,23 @@ enum Commands {
         #[arg(long)]
         path: bool,
     },
+    /// Show the resolved environment a managed app's web process would receive
+    Env {
+        /// App name or domain (omit to match CWD)
+        name: Option<String>,
+        /// Print as plain KEY=value lines (no source column)
+        #[arg(long)]
+        bare: bool,
+        /// Print as JSON (array of {key, value, source})
+        #[arg(long)]
+        json: bool,
+        /// Show the would-be env (re-resolved now) instead of the running process
+        #[arg(long)]
+        preview: bool,
+        /// With --preview, do not fetch env_url (offline)
+        #[arg(long)]
+        no_remote: bool,
+    },
     /// Show running managed processes
     Ps,
     /// Start a managed process
@@ -1472,6 +1489,13 @@ async fn main() -> anyhow::Result<()> {
             lines,
             path,
         } => run_logs(cfg, name, follow, lines, path),
+        Commands::Env {
+            name,
+            bare,
+            json,
+            preview,
+            no_remote,
+        } => run_env(cfg, name, bare, json, preview, no_remote).await,
         Commands::Ps => run_ps(cfg),
         Commands::Start { name } => run_process_action(cfg, name, "process.start"),
         Commands::Stop { name } => run_process_action(cfg, name, "process.stop"),
@@ -2106,6 +2130,157 @@ fn resolve_app_id(
         .ok_or_else(|| anyhow::anyhow!("app not found: {bare_name}"))?;
 
     Ok((bare_name, app_id))
+}
+
+async fn run_env(
+    cfg: CoulsonConfig,
+    name: Option<String>,
+    bare: bool,
+    json: bool,
+    preview: bool,
+    no_remote: bool,
+) -> anyhow::Result<()> {
+    // Each row is (key, value, source_kind, source_label).
+    let rows: Vec<(String, String, String, String)> = if preview {
+        // Re-resolve locally: what the app *would* get if started now.
+        let bare_name = resolve_app_name(&cfg, name.as_deref())?;
+        let domain_match = format!("{bare_name}.{}", cfg.domain_suffix);
+        let state = build_state(&cfg)?;
+        let app = state
+            .store
+            .list_all()?
+            .into_iter()
+            .find(|a| a.name == bare_name || a.domain.0 == domain_match || a.domain.0 == bare_name)
+            .ok_or_else(|| anyhow::anyhow!("app not found: {bare_name}"))?;
+        let (app_id, root, kind, mname) = match &app.target {
+            crate::domain::BackendTarget::Managed {
+                app_id,
+                root,
+                kind,
+                name,
+            } => (*app_id, root.clone(), kind.clone(), name.clone()),
+            _ => bail!(
+                "`coulson env` is only available for managed apps; {bare_name} is a static/proxy app"
+            ),
+        };
+        let entries = {
+            let pm = state.process_manager.lock().await;
+            pm.inspect_env(
+                app_id,
+                &mname,
+                std::path::Path::new(&root),
+                &kind,
+                !no_remote,
+            )
+            .await?
+        };
+        eprintln!(
+            "{}",
+            "(preview — computed now, not the running process; PORT is a preview allocation)"
+                .dimmed()
+        );
+        entries
+            .into_iter()
+            .map(|e| {
+                let kind = e.source.kind().to_string();
+                let label = e.source.label();
+                (e.key, e.value, kind, label)
+            })
+            .collect()
+    } else {
+        // Live: the env the running process was actually started with.
+        let client = RpcClient::new(&cfg.control_socket);
+        let (_bare_name, app_id) = resolve_app_id(&client, &cfg, name)?;
+        let result = client.call("process.env", serde_json::json!({ "app_id": app_id }))?;
+        result
+            .get("env")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|e| {
+                        let key = e.get("key")?.as_str()?.to_string();
+                        let value = e.get("value")?.as_str()?.to_string();
+                        let source = e.get("source")?;
+                        let kind = source.get("kind")?.as_str()?.to_string();
+                        let label = source.get("label")?.as_str()?.to_string();
+                        Some((key, value, kind, label))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
+    if json {
+        let arr: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|(k, v, kind, label)| {
+                serde_json::json!({
+                    "key": k,
+                    "value": v,
+                    "source": { "kind": kind, "label": label },
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr)?);
+        return Ok(());
+    }
+    if bare {
+        for (k, v, _, _) in &rows {
+            println!("{k}={v}");
+        }
+        return Ok(());
+    }
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    // Aligned KEY + SOURCE columns (bounded widths); VALUE last. Long values
+    // are truncated to the terminal width so rows stay one line and aligned.
+    // When output is not a TTY (piped), values are shown in full.
+    let key_w = rows
+        .iter()
+        .map(|(k, ..)| k.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("KEY".len());
+    let src_w = rows
+        .iter()
+        .map(|(_, _, _, label)| label.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("SOURCE".len());
+
+    const SEP: usize = 2; // spaces between columns
+    let value_budget = terminal_size::terminal_size().map(|(w, _)| {
+        (w.0 as usize)
+            .saturating_sub(key_w + src_w + SEP * 2)
+            .max(8)
+    });
+
+    println!(
+        "{}  {}  {}",
+        format!("{:<key_w$}", "KEY").dimmed(),
+        format!("{:<src_w$}", "SOURCE").dimmed(),
+        "VALUE".dimmed()
+    );
+    for (k, v, kind, label) in &rows {
+        let src_cell = format!("{label:<src_w$}");
+        let src_cell = match kind.as_str() {
+            "dotenv" => src_cell.green(),
+            "env_url" => src_cell.cyan(),
+            "toml" => src_cell.yellow(),
+            _ => src_cell.dimmed(),
+        };
+        let value = match value_budget {
+            Some(budget) if v.chars().count() > budget => {
+                let head: String = v.chars().take(budget.saturating_sub(1)).collect();
+                format!("{head}…")
+            }
+            _ => v.clone(),
+        };
+        println!("{}  {}  {}", format!("{k:<key_w$}").bold(), src_cell, value);
+    }
+    Ok(())
 }
 
 fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {

--- a/crates/coulson/src/process/asgi.rs
+++ b/crates/coulson/src/process/asgi.rs
@@ -58,12 +58,9 @@ impl ProcessProvider for AsgiProvider {
         // access logs hit the log file immediately instead of sitting in
         // Python's block buffer (which kicks in when stdout is a file).
         env.insert("PYTHONUNBUFFERED".into(), "1".into());
-        // uvicorn's Click CLI enables `auto_envvar_prefix="UVICORN"`, so any
-        // flag can be toggled via `UVICORN_<FLAG>` env vars the user sets in
-        // `.coulson.toml` / env_overrides (e.g. `UVICORN_RELOAD=true`,
-        // `UVICORN_LOG_LEVEL=debug`). No need to special-case individual
-        // flags here.
-        env.extend(app.env_overrides.clone());
+        // Provider returns framework defaults only. User env (incl. uvicorn's
+        // `UVICORN_*` flags via Click's `auto_envvar_prefix`) is layered on top
+        // by the orchestrator from `.coulson.toml [env]` / env_url / `.coulsonrc`.
 
         Ok(ProcessSpec {
             command: binary,
@@ -335,25 +332,41 @@ mod tests {
     #[test]
     fn uvicorn_env_overrides_are_preserved() {
         // uvicorn supports `UVICORN_*` env vars natively via Click's
-        // `auto_envvar_prefix`. Make sure the provider just passes them
-        // through without stripping or translating.
+        // `auto_envvar_prefix`. The provider returns defaults-only now — the
+        // user's `UVICORN_*` are layered on top by the orchestrator. Verify the
+        // provider does NOT bake them in, but they survive into the merged env.
         let root = temp_app_dir("uvicorn-env-passthrough");
         fs::write(root.join("app.py"), "").unwrap();
         place_venv_binary(&root, "uvicorn");
-        let app = make_managed_app(
-            &root,
-            vec![("UVICORN_RELOAD", "true"), ("UVICORN_LOG_LEVEL", "debug")],
-        );
+        let app = make_managed_app(&root, vec![]);
         let spec = AsgiProvider.resolve(&app).unwrap();
+        // Defaults-only: PYTHONUNBUFFERED yes, no user UVICORN_* mixed in.
         assert_eq!(
-            spec.env.get("UVICORN_RELOAD").map(String::as_str),
+            spec.env.get("PYTHONUNBUFFERED").map(String::as_str),
+            Some("1")
+        );
+        assert!(!spec.env.contains_key("UVICORN_RELOAD"));
+        assert!(!spec.args.contains(&"--reload".to_string()));
+
+        // Layered on top (via `.coulsonrc`), UVICORN_* reach the merged child env.
+        let coulsonrc = std::collections::HashMap::from([
+            ("UVICORN_RELOAD".to_string(), "true".to_string()),
+            ("UVICORN_LOG_LEVEL".to_string(), "debug".to_string()),
+        ]);
+        let merged =
+            crate::process::build_layered_env(spec.env, &None, None, &coulsonrc, &root).merge();
+        assert_eq!(
+            merged.get("UVICORN_RELOAD").map(String::as_str),
             Some("true")
         );
         assert_eq!(
-            spec.env.get("UVICORN_LOG_LEVEL").map(String::as_str),
+            merged.get("UVICORN_LOG_LEVEL").map(String::as_str),
             Some("debug")
         );
-        assert!(!spec.args.contains(&"--reload".to_string()));
+        assert_eq!(
+            merged.get("PYTHONUNBUFFERED").map(String::as_str),
+            Some("1")
+        );
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/coulson/src/process/docker.rs
+++ b/crates/coulson/src/process/docker.rs
@@ -200,7 +200,6 @@ impl ProcessProvider for DockerProvider {
 
         let mut env = std::collections::HashMap::new();
         env.insert("PORT".to_string(), port.to_string());
-        env.extend(app.env_overrides.clone());
 
         debug!(
             root = %root.display(),

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -86,6 +86,9 @@ struct ManagedProcess {
     last_active: Instant,
     kind: String,
     ready: bool,
+    /// The environment this process was started with (merged, with provenance),
+    /// captured at spawn so `coulson env` can show the live values.
+    resolved_env: Vec<EnvEntry>,
 }
 
 #[allow(dead_code)]
@@ -134,6 +137,124 @@ pub struct ProcessInfo {
     pub idle_secs: u64,
     pub alive: bool,
     pub backend: String,
+}
+
+/// Which layer a resolved env var's winning value came from. Mirrors the
+/// precedence in [`LayeredEnv`]. `Dotenv` carries the file path because there
+/// can be more than one dotenv file (today `.coulsonrc`; future `.env`, etc.),
+/// each its own layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvSource {
+    Provider,
+    TomlEnv,
+    EnvUrl,
+    Dotenv(PathBuf),
+}
+
+impl EnvSource {
+    /// Stable machine label for the source kind (used for grouping/coloring).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            EnvSource::Provider => "provider",
+            EnvSource::TomlEnv => "toml",
+            EnvSource::EnvUrl => "env_url",
+            EnvSource::Dotenv(_) => "dotenv",
+        }
+    }
+
+    /// Human-readable label: the concrete file for dotenv, else the kind.
+    pub fn label(&self) -> String {
+        match self {
+            EnvSource::Provider => "provider".to_string(),
+            EnvSource::TomlEnv => ".coulson.toml".to_string(),
+            EnvSource::EnvUrl => "env_url".to_string(),
+            EnvSource::Dotenv(path) => path
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+        }
+    }
+
+    /// Precedence rank (low → high). Used to order resolved entries so the
+    /// highest-priority overrides sort last.
+    fn rank(&self) -> u8 {
+        match self {
+            EnvSource::Provider => 0,
+            EnvSource::TomlEnv => 1,
+            EnvSource::EnvUrl => 2,
+            EnvSource::Dotenv(_) => 3,
+        }
+    }
+}
+
+impl serde::Serialize for EnvSource {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut st = s.serialize_struct("EnvSource", 2)?;
+        st.serialize_field("kind", self.kind())?;
+        st.serialize_field("label", &self.label())?;
+        st.end()
+    }
+}
+
+/// One resolved environment variable with the source that won it. Produced by
+/// [`LayeredEnv::resolve`] and surfaced by the `coulson env` command.
+#[derive(Clone, serde::Serialize)]
+pub struct EnvEntry {
+    pub key: String,
+    pub value: String,
+    pub source: EnvSource,
+}
+
+/// An ordered stack of named environment layers, lowest precedence first. Both
+/// the merged environment and the per-variable provenance derive from the same
+/// fold, so they cannot disagree — no double application, no reverse lookup.
+///
+/// Precedence (low → high): `Provider < TomlEnv < EnvUrl < Dotenv(.coulsonrc)`.
+#[derive(Default)]
+pub(crate) struct LayeredEnv {
+    layers: Vec<(EnvSource, HashMap<String, String>)>,
+}
+
+impl LayeredEnv {
+    /// Add a layer. Empty layers are dropped (they cannot affect the result).
+    fn push(&mut self, source: EnvSource, vars: HashMap<String, String>) {
+        if !vars.is_empty() {
+            self.layers.push((source, vars));
+        }
+    }
+
+    /// The final merged environment; higher layers win.
+    fn merge(&self) -> HashMap<String, String> {
+        let mut out = HashMap::new();
+        for (_src, vars) in &self.layers {
+            for (k, v) in vars {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+        out
+    }
+
+    /// Every key with its winning value and the layer that set it, ordered by
+    /// source precedence (low → high) then key — so the highest-priority
+    /// overrides (`.coulsonrc`) sort last.
+    fn resolve(&self) -> Vec<EnvEntry> {
+        let mut map: std::collections::BTreeMap<String, (String, EnvSource)> =
+            std::collections::BTreeMap::new();
+        for (src, vars) in &self.layers {
+            for (k, v) in vars {
+                map.insert(k.clone(), (v.clone(), src.clone()));
+            }
+        }
+        // BTreeMap gives key order; stable-sort by rank preserves key order
+        // within each precedence tier.
+        let mut entries: Vec<EnvEntry> = map
+            .into_iter()
+            .map(|(key, (value, source))| EnvEntry { key, value, source })
+            .collect();
+        entries.sort_by_key(|e| e.source.rank());
+        entries
+    }
 }
 
 impl ProcessManager {
@@ -192,6 +313,18 @@ impl ProcessManager {
             types.push(c.process_type.clone());
         }
         types
+    }
+
+    /// The resolved environment (with provenance) the running web process was
+    /// started with. `None` if no process is tracked for this app, or the
+    /// tracked process has already exited (so callers report "not running"
+    /// instead of stale env for a dead handle).
+    pub fn process_env(&mut self, app_id: i64) -> Option<&[EnvEntry]> {
+        let group = self.processes.get_mut(&app_id)?;
+        if !is_alive(&mut group.primary.handle) {
+            return None;
+        }
+        Some(group.primary.resolved_env.as_slice())
     }
 
     /// Whether log broadcast is available (direct/compose backends).
@@ -270,12 +403,11 @@ impl ProcessManager {
             cleanup_listen_target(&removed.primary.listen_target);
         }
 
-        let (mut spec, sockets_dir, prov_name, companion_types, manifest) =
+        let (mut spec, sockets_dir, prov_name, companion_types, manifest, coulsonrc) =
             self.resolve_spec(app_id, name, root, kind)?;
 
-        if let Some(remote_env) = env_url_env.as_ref() {
-            merge_remote_env(&mut spec, remote_env.clone(), &manifest);
-        }
+        let resolved_env =
+            apply_and_capture_env(&mut spec, &manifest, env_url_env.as_ref(), &coulsonrc, root);
 
         let log_path = resolve_log_path(&manifest, root, &sockets_dir, name);
         if let Some(parent) = log_path.parent() {
@@ -372,6 +504,7 @@ impl ProcessManager {
             env_url_env.as_ref(),
             &log_path,
             log_tx,
+            &coulsonrc,
         );
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
@@ -386,6 +519,7 @@ impl ProcessManager {
                     last_active: now,
                     kind: kind.to_string(),
                     ready: true,
+                    resolved_env,
                 },
                 companions,
                 name: name.to_string(),
@@ -490,12 +624,11 @@ impl ProcessManager {
             None => {} // No existing process, proceed to spawn
         }
 
-        let (mut spec, sockets_dir, prov_name, companion_types, manifest) =
+        let (mut spec, sockets_dir, prov_name, companion_types, manifest, coulsonrc) =
             self.resolve_spec(app_id, name, root, kind)?;
 
-        if let Some(remote_env) = env_url_env.as_ref() {
-            merge_remote_env(&mut spec, remote_env.clone(), &manifest);
-        }
+        let resolved_env =
+            apply_and_capture_env(&mut spec, &manifest, env_url_env.as_ref(), &coulsonrc, root);
 
         let log_path = resolve_log_path(&manifest, root, &sockets_dir, name);
         if let Some(parent) = log_path.parent() {
@@ -576,6 +709,7 @@ impl ProcessManager {
             env_url_env.as_ref(),
             &log_path,
             log_tx,
+            &coulsonrc,
         );
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
@@ -590,6 +724,7 @@ impl ProcessManager {
                     last_active: now,
                     kind: kind.to_string(),
                     ready: false,
+                    resolved_env,
                 },
                 companions,
                 name: name.to_string(),
@@ -699,7 +834,9 @@ impl ProcessManager {
 
     /// Resolve a ProcessSpec from the provider registry.
     /// Returns the spec, sockets directory, provider name, companion types,
-    /// and the loaded `.coulson.toml` manifest (if any) for env re-application.
+    /// the loaded `.coulson.toml` manifest (if any) for env re-application, and
+    /// the parsed `.coulsonrc` snapshot so the caller can finalize the env from
+    /// the same single read (no re-parse, no TOCTOU).
     #[allow(clippy::type_complexity)]
     fn resolve_spec(
         &self,
@@ -713,6 +850,7 @@ impl ProcessManager {
         String,
         Vec<String>,
         Option<serde_json::Value>,
+        HashMap<String, String>,
     )> {
         let prov = self
             .registry
@@ -747,16 +885,16 @@ impl ProcessManager {
             root: root.to_path_buf(),
             kind: kind.to_string(),
             manifest,
-            env_overrides,
+            env_overrides: env_overrides.clone(),
             socket_dir: sockets_dir.clone(),
         };
 
-        let mut spec = prov.resolve(&managed_app)?;
-        // Do not pass COULSON_MANAGED_SERVICES to child processes
-        spec.env.remove("COULSON_MANAGED_SERVICES");
-
-        // Inject [env] from .coulson.toml (overrides provider defaults and .coulsonrc)
-        apply_manifest_env(&mut spec, &managed_app.manifest);
+        // Provider seeds `spec.env` with its defaults plus an early (low
+        // precedence) copy of `.coulsonrc`. The authoritative env layering
+        // (toml `[env]` < env_url < `.coulsonrc`) and the managed-services
+        // strip are applied later by `finalize_managed_env`, once env_url has
+        // been fetched.
+        let spec = prov.resolve(&managed_app)?;
 
         let _ = app_id; // used in caller for logging
         Ok((
@@ -765,7 +903,41 @@ impl ProcessManager {
             prov.display_name().to_string(),
             companion_types,
             managed_app.manifest,
+            env_overrides,
         ))
+    }
+
+    /// Resolve the environment a managed app's **web** process would receive,
+    /// annotating each variable with the source that won it — WITHOUT spawning.
+    ///
+    /// Reuses the real spawn path (`resolve_spec` + `finalize_managed_env`) so
+    /// the result matches what the child would actually get. Resolving the
+    /// provider spec has the same side effects as a real start (binary
+    /// detection, and a transient free-port probe for TCP providers). When
+    /// `fetch_remote` is true, `env_url` is fetched. Used by `coulson env`.
+    pub async fn inspect_env(
+        &self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        fetch_remote: bool,
+    ) -> anyhow::Result<Vec<EnvEntry>> {
+        let (spec, _sockets_dir, _prov_name, _companion_types, manifest, coulsonrc) =
+            self.resolve_spec(app_id, name, root, kind)?;
+
+        let env_url_env = if fetch_remote {
+            prefetch_env_url(root).await?
+        } else {
+            None
+        };
+
+        // Provenance falls straight out of the layered fold — no reverse lookup.
+        let layered =
+            build_layered_env(spec.env, &manifest, env_url_env.as_ref(), &coulsonrc, root);
+        let mut entries = layered.resolve();
+        entries.retain(|e| e.key != "COULSON_MANAGED_SERVICES");
+        Ok(entries)
     }
 
     /// Spawn a process using the current backend (direct or tmux).
@@ -790,10 +962,9 @@ impl ProcessManager {
     /// Spawn companion processes for a Procfile app.
     ///
     /// `manifest` and `remote_env` are passed through so companion specs receive
-    /// the same env treatment as the web process: `.coulson.toml [env]` and any
-    /// `env_url`-fetched values are merged on top of `.coulsonrc`, with local
-    /// manifest values winning over remote. Without this, workers/schedulers
-    /// would see only `.coulsonrc` and miss secrets like `DATABASE_URL`.
+    /// the same layered env as the web process (provider defaults < `.coulson.toml
+    /// [env]` < `env_url` < `.coulsonrc`). Without this, workers/schedulers would
+    /// see only `.coulsonrc` and miss secrets like `DATABASE_URL`.
     #[allow(clippy::too_many_arguments)]
     fn spawn_companions(
         &self,
@@ -807,18 +978,18 @@ impl ProcessManager {
         remote_env: Option<&HashMap<String, String>>,
         primary_log_path: &Path,
         log_tx: &broadcast::Sender<LogLine>,
+        coulsonrc: &HashMap<String, String>,
     ) -> Vec<CompanionProcess> {
         if companion_types.is_empty() || kind != "procfile" {
             return vec![];
         }
 
-        let env_overrides = crate::process::provider::load_coulsonrc(root);
         let managed_app = ManagedApp {
             name: name.to_string(),
             root: root.to_path_buf(),
             kind: kind.to_string(),
             manifest: manifest.clone(),
-            env_overrides,
+            env_overrides: coulsonrc.clone(),
             socket_dir: sockets_dir.to_path_buf(),
         };
 
@@ -838,13 +1009,9 @@ impl ProcessManager {
                             port: 0,
                         },
                     };
-                    // Apply the same env precedence as the web process:
-                    // .coulsonrc (from resolve_companion) → env_url → manifest [env]
-                    if let Some(remote) = remote_env {
-                        merge_remote_env(&mut spec, remote.clone(), manifest);
-                    } else {
-                        apply_manifest_env(&mut spec, manifest);
-                    }
+                    // Same env precedence as the web process (companion env is
+                    // applied but not stored for inspection this pass).
+                    let _ = apply_and_capture_env(&mut spec, manifest, remote_env, coulsonrc, root);
                     let log_path = primary_log_path
                         .parent()
                         .unwrap_or(sockets_dir)
@@ -1189,28 +1356,94 @@ pub(crate) fn load_coulson_toml_manifest(root: &Path) -> Option<serde_json::Valu
     }
 }
 
-/// Merge pre-fetched remote env vars into a spec, then re-apply `[env]` from
-/// the manifest so local config wins over remote values.
-fn merge_remote_env(
-    spec: &mut ProcessSpec,
-    remote_env: HashMap<String, String>,
-    manifest: &Option<serde_json::Value>,
-) {
-    spec.env.extend(remote_env);
-    apply_manifest_env(spec, manifest);
-}
-
-/// Apply `[env]` section from a `.coulson.toml` manifest into a ProcessSpec.
-fn apply_manifest_env(spec: &mut ProcessSpec, manifest: &Option<serde_json::Value>) {
-    if let Some(m) = manifest {
-        if let Some(env_obj) = m.get("env").and_then(|v| v.as_object()) {
-            for (k, v) in env_obj {
-                if let Some(val) = v.as_str() {
-                    spec.env.insert(k.clone(), val.to_string());
-                }
+/// Extract the `[env]` table of a `.coulson.toml` manifest as a map.
+fn manifest_env_map(manifest: &Option<serde_json::Value>) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    if let Some(obj) = manifest
+        .as_ref()
+        .and_then(|m| m.get("env"))
+        .and_then(|v| v.as_object())
+    {
+        for (k, v) in obj {
+            if let Some(val) = v.as_str() {
+                out.insert(k.clone(), val.to_string());
             }
         }
     }
+    out
+}
+
+/// Build the [`LayeredEnv`] for a managed process from all sources, lowest
+/// precedence first. `provider_defaults` is the provider's framework env (PORT,
+/// PYTHONUNBUFFERED, …) with no user config mixed in.
+///
+/// Precedence: `provider defaults < .coulson.toml [env] < env_url < .coulsonrc`.
+/// `coulsonrc` is the snapshot parsed once at the start of the spawn, passed in
+/// so selection decisions and the final env agree on one file read.
+///
+/// `PORT` is special: it is the contract between the child (bind address) and
+/// the port Coulson proxies to (`listen_target`), which the provider chose via
+/// `resolve_port` (reading the manifest `port` / `.coulsonrc` / allocation).
+/// `resolve_port` never consults `.coulson.toml [env]` or `env_url`, so a `PORT`
+/// in those layers would desync the child's `$PORT` from `listen_target` and
+/// break routing. It is therefore stripped from those overlay layers; the
+/// provider-chosen value (echoed by `.coulsonrc` when set there) stands.
+fn build_layered_env(
+    provider_defaults: HashMap<String, String>,
+    manifest: &Option<serde_json::Value>,
+    env_url_env: Option<&HashMap<String, String>>,
+    coulsonrc: &HashMap<String, String>,
+    root: &Path,
+) -> LayeredEnv {
+    let mut env = LayeredEnv::default();
+    env.push(EnvSource::Provider, provider_defaults);
+
+    let mut toml = manifest_env_map(manifest);
+    if toml.remove("PORT").is_some() {
+        debug!("ignoring PORT in .coulson.toml [env]; PORT is managed by the provider");
+    }
+    env.push(EnvSource::TomlEnv, toml);
+
+    if let Some(remote) = env_url_env {
+        let mut remote = remote.clone();
+        if remote.remove("PORT").is_some() {
+            debug!("ignoring PORT from env_url; PORT is managed by the provider");
+        }
+        env.push(EnvSource::EnvUrl, remote);
+    }
+
+    env.push(
+        EnvSource::Dotenv(root.join(".coulsonrc")),
+        coulsonrc.clone(),
+    );
+    env
+}
+
+/// Apply the layered environment onto `spec.env` (merged, with the
+/// `COULSON_MANAGED_SERVICES` meta-var stripped) and return the resolved entries
+/// (with provenance, meta-var stripped) for storage / inspection. The meta-var
+/// selects companion processes and must never reach the child environment.
+fn apply_and_capture_env(
+    spec: &mut ProcessSpec,
+    manifest: &Option<serde_json::Value>,
+    env_url_env: Option<&HashMap<String, String>>,
+    coulsonrc: &HashMap<String, String>,
+    root: &Path,
+) -> Vec<EnvEntry> {
+    let layered = build_layered_env(
+        std::mem::take(&mut spec.env),
+        manifest,
+        env_url_env,
+        coulsonrc,
+        root,
+    );
+    let mut merged = layered.merge();
+    merged.remove("COULSON_MANAGED_SERVICES");
+    spec.env = merged;
+
+    let mut entries = layered.resolve();
+    entries.retain(|e| e.key != "COULSON_MANAGED_SERVICES");
+    entries
 }
 
 /// Parse environment variables from a response body.
@@ -1234,15 +1467,15 @@ fn parse_env_body(body: &str, content_type: &str) -> anyhow::Result<HashMap<Stri
             }
         }
     } else {
-        for line in body.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-            let line = line.strip_prefix("export ").unwrap_or(line);
-            if let Some((k, v)) = line.split_once('=') {
-                let v = v.trim_matches('"').trim_matches('\'');
-                env.insert(k.trim().to_string(), v.to_string());
+        // dotenv body: parse with dotenvy (same engine as `.coulsonrc`).
+        for item in dotenvy::from_read_iter(body.as_bytes()) {
+            match item {
+                Ok((k, v)) => {
+                    env.insert(k, v);
+                }
+                Err(e) => {
+                    debug!(error = %e, "skipping invalid dotenv line from env_url");
+                }
             }
         }
     }
@@ -2456,11 +2689,167 @@ mod tests {
             !script.contains(" sh -c "),
             "wrapper must not downgrade to sh -c, got:\n{script}"
         );
-        // env(1) prefix must still be present so rc-file overrides lose.
+        // env(1) prefix must still be present so the login shell's rc files
+        // (~/.zshrc etc.) cannot override the injected spec env. (This is the
+        // shell rc layer, unrelated to `.coulsonrc` precedence.)
         assert!(
             script.contains("env '"),
             "wrapper should re-apply env via env(1), got:\n{script}"
         );
+    }
+
+    #[test]
+    fn finalize_managed_env_precedence_and_strips_managed_services() {
+        use crate::process::provider::ListenTarget;
+        let dir =
+            std::env::temp_dir().join(format!("coulson-test-finalize-env-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(".coulsonrc"),
+            "RC_WINS=from_rc\nCOULSON_MANAGED_SERVICES=worker\nONLY_RC=r\n",
+        )
+        .unwrap();
+
+        // `.coulson.toml [env]` carries some keys; `env_url` and `.coulsonrc`
+        // override subsets so each precedence edge is exercised.
+        let manifest = Some(serde_json::json!({
+            "env": {
+                "RC_WINS": "from_toml",
+                "URL_WINS": "from_toml",
+                "ONLY_TOML": "t",
+            }
+        }));
+        let mut url = HashMap::new();
+        url.insert("URL_WINS".to_string(), "from_url".to_string());
+        url.insert("ONLY_URL".to_string(), "u".to_string());
+
+        // Provider seed: defaults + early low-priority `.coulsonrc` copy.
+        let mut env = HashMap::new();
+        env.insert("ONLY_PROVIDER".to_string(), "p".to_string());
+        let mut spec = ProcessSpec {
+            command: PathBuf::new(),
+            args: vec![],
+            env,
+            working_dir: PathBuf::from("/tmp"),
+            listen_target: ListenTarget::Tcp {
+                host: String::new(),
+                port: 0,
+            },
+        };
+
+        let coulsonrc = crate::process::provider::load_coulsonrc(&dir);
+        let entries = apply_and_capture_env(&mut spec, &manifest, Some(&url), &coulsonrc, &dir);
+
+        // --- merged child env: precedence + survival + strip ---
+        // `.coulsonrc` (manual local override) beats both toml and env_url.
+        assert_eq!(spec.env.get("RC_WINS").map(String::as_str), Some("from_rc"));
+        // env_url beats `.coulson.toml [env]`.
+        assert_eq!(
+            spec.env.get("URL_WINS").map(String::as_str),
+            Some("from_url")
+        );
+        // Each unique key from every layer survives.
+        assert_eq!(spec.env.get("ONLY_TOML").map(String::as_str), Some("t"));
+        assert_eq!(spec.env.get("ONLY_URL").map(String::as_str), Some("u"));
+        assert_eq!(spec.env.get("ONLY_RC").map(String::as_str), Some("r"));
+        assert_eq!(spec.env.get("ONLY_PROVIDER").map(String::as_str), Some("p"));
+        // The managed-services meta-var must never leak into the child env.
+        assert!(!spec.env.contains_key("COULSON_MANAGED_SERVICES"));
+
+        // --- captured provenance: winning source per key, meta-var excluded ---
+        let kind = |k: &str| entries.iter().find(|e| e.key == k).map(|e| e.source.kind());
+        assert_eq!(kind("RC_WINS"), Some("dotenv"));
+        assert_eq!(kind("URL_WINS"), Some("env_url"));
+        assert_eq!(kind("ONLY_TOML"), Some("toml"));
+        assert_eq!(kind("ONLY_PROVIDER"), Some("provider"));
+        assert!(kind("COULSON_MANAGED_SERVICES").is_none());
+        // The dotenv source carries the concrete file.
+        let rc = entries.iter().find(|e| e.key == "RC_WINS").unwrap();
+        assert!(matches!(&rc.source, EnvSource::Dotenv(p) if p.ends_with(".coulsonrc")));
+        // Ordered by source precedence (low → high), key within tier.
+        let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec![
+                "ONLY_PROVIDER",
+                "ONLY_TOML",
+                "ONLY_URL",
+                "URL_WINS",
+                "ONLY_RC",
+                "RC_WINS"
+            ]
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn layered_env_merge_and_resolve() {
+        let mut env = LayeredEnv::default();
+        env.push(
+            EnvSource::Provider,
+            HashMap::from([("A".into(), "prov".into()), ("PORT".into(), "1".into())]),
+        );
+        env.push(
+            EnvSource::TomlEnv,
+            HashMap::from([("A".into(), "toml".into()), ("B".into(), "toml".into())]),
+        );
+        env.push(
+            EnvSource::EnvUrl,
+            HashMap::from([("B".into(), "url".into()), ("C".into(), "url".into())]),
+        );
+        env.push(
+            EnvSource::Dotenv(PathBuf::from("/app/.coulsonrc")),
+            HashMap::from([("A".into(), "rc".into()), ("D".into(), "rc".into())]),
+        );
+
+        // merge: higher layers win.
+        let merged = env.merge();
+        assert_eq!(merged.get("A").map(String::as_str), Some("rc")); // dotenv top
+        assert_eq!(merged.get("B").map(String::as_str), Some("url")); // env_url > toml
+        assert_eq!(merged.get("C").map(String::as_str), Some("url"));
+        assert_eq!(merged.get("D").map(String::as_str), Some("rc"));
+        assert_eq!(merged.get("PORT").map(String::as_str), Some("1")); // provider-only
+
+        // resolve: same fold, tagged with the winning source; sorted by key.
+        let resolved = env.resolve();
+        let kind = |k: &str| {
+            resolved
+                .iter()
+                .find(|e| e.key == k)
+                .map(|e| e.source.kind())
+        };
+        assert_eq!(kind("A"), Some("dotenv"));
+        assert_eq!(kind("B"), Some("env_url"));
+        assert_eq!(kind("C"), Some("env_url"));
+        assert_eq!(kind("PORT"), Some("provider"));
+        // Ordered by source precedence (low → high), key within tier:
+        // provider(PORT) < env_url(B,C) < dotenv(A,D).
+        let keys: Vec<&str> = resolved.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(keys, vec!["PORT", "B", "C", "A", "D"]);
+    }
+
+    #[test]
+    fn port_is_reserved_from_toml_and_env_url() {
+        // PORT is the provider/listen_target contract; toml [env] and env_url
+        // must not be able to override it (resolve_port never reads them).
+        let provider = HashMap::from([("PORT".to_string(), "PROVIDER".to_string())]);
+        let manifest = Some(serde_json::json!({ "env": { "PORT": "9999", "X": "x" } }));
+        let url = HashMap::from([("PORT".to_string(), "8888".to_string())]);
+        let coulsonrc = HashMap::new();
+        let merged = build_layered_env(
+            provider,
+            &manifest,
+            Some(&url),
+            &coulsonrc,
+            Path::new("/app"),
+        )
+        .merge();
+        // PORT stays the provider's value; overlays' PORT is stripped.
+        assert_eq!(merged.get("PORT").map(String::as_str), Some("PROVIDER"));
+        // Non-PORT overlay keys still apply.
+        assert_eq!(merged.get("X").map(String::as_str), Some("x"));
     }
 
     #[test]

--- a/crates/coulson/src/process/node.rs
+++ b/crates/coulson/src/process/node.rs
@@ -69,7 +69,6 @@ impl ProcessProvider for NodeProvider {
                 let port = resolve_port(&app.env_overrides)?;
                 let mut env = std::collections::HashMap::new();
                 env.insert("PORT".to_string(), port.to_string());
-                env.extend(app.env_overrides.clone());
                 return Ok(ProcessSpec {
                     command: PathBuf::from(cmd),
                     args: vec![],
@@ -100,7 +99,6 @@ impl ProcessProvider for NodeProvider {
 
         let mut env = std::collections::HashMap::new();
         env.insert("PORT".to_string(), port.to_string());
-        env.extend(app.env_overrides.clone());
 
         let listen_target = ListenTarget::Tcp {
             host: "127.0.0.1".to_string(),

--- a/crates/coulson/src/process/procfile.rs
+++ b/crates/coulson/src/process/procfile.rs
@@ -80,15 +80,13 @@ impl ProcfileProvider {
             format!("{} {}", entry.command, entry.options.join(" "))
         };
 
-        // Companion gets env_overrides but no PORT, no COULSON_MANAGED_SERVICES
-        let mut env = app.env_overrides.clone();
-        env.remove("COULSON_MANAGED_SERVICES");
-
+        // Companion has no framework defaults (no PORT). User env is layered on
+        // top by the orchestrator, which also strips COULSON_MANAGED_SERVICES.
         Ok(CompanionSpec {
             process_type: process_type.to_string(),
             command: PathBuf::new(),
             args: vec![full_command],
-            env,
+            env: HashMap::new(),
             working_dir: root.clone(),
         })
     }
@@ -138,7 +136,6 @@ impl ProcessProvider for ProcfileProvider {
                 let port = resolve_port(&app.env_overrides)?;
                 let mut env = HashMap::new();
                 env.insert("PORT".to_string(), port.to_string());
-                env.extend(app.env_overrides.clone());
                 return Ok(ProcessSpec {
                     command: PathBuf::new(),
                     args: vec![cmd.to_string()],
@@ -174,7 +171,6 @@ impl ProcessProvider for ProcfileProvider {
         let port = resolve_port(&app.env_overrides)?;
         let mut env = HashMap::new();
         env.insert("PORT".to_string(), port.to_string());
-        env.extend(app.env_overrides.clone());
 
         debug!(
             root = %root.display(),

--- a/crates/coulson/src/process/provider.rs
+++ b/crates/coulson/src/process/provider.rs
@@ -238,43 +238,40 @@ pub fn resolve_port(env: &HashMap<String, String>) -> Result<u16> {
     }
 }
 
-/// Parse a `.coulsonrc` file from the app root directory.
+/// Load the `.coulsonrc` file from the app root directory.
 ///
-/// Format: simple `KEY=VALUE` lines (shell-style). Supports:
-/// - `#` comments and blank lines
-/// - Optional quoting (`KEY="value"` or `KEY='value'`)
-/// - `export KEY=VALUE` prefix
+/// `.coulsonrc` is the **manual, local override** file (typically gitignored),
+/// as opposed to `.coulson.toml` which holds programmatic/provisioned config.
+/// It therefore takes the highest precedence in env resolution (applied last).
+///
+/// Parsed with `dotenvy` (standard dotenv semantics): `KEY=VALUE`, `#`
+/// comments, `export` prefix, quoting, and `${VAR}` interpolation. Because
+/// interpolation is enabled, a literal `$` must be escaped (`\$`) or
+/// single-quoted. Parsing never mutates the daemon's own environment.
 pub fn load_coulsonrc(root: &Path) -> HashMap<String, String> {
-    let path = root.join(".coulsonrc");
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(_) => return HashMap::new(),
-    };
-    debug!(path = %path.display(), "loaded .coulsonrc");
-    parse_dotenv(&content)
+    parse_dotenv_file(&root.join(".coulsonrc"))
 }
 
-fn parse_dotenv(content: &str) -> HashMap<String, String> {
+/// Parse a dotenv-format file into a map via `dotenvy`, without touching the
+/// process environment. A missing file yields an empty map.
+pub fn parse_dotenv_file(path: &Path) -> HashMap<String, String> {
     let mut env = HashMap::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
+    match dotenvy::from_path_iter(path) {
+        Ok(iter) => {
+            for item in iter {
+                match item {
+                    Ok((key, val)) => {
+                        env.insert(key, val);
+                    }
+                    Err(e) => {
+                        debug!(path = %path.display(), error = %e, "skipping invalid dotenv entry");
+                    }
+                }
+            }
+            debug!(path = %path.display(), count = env.len(), "loaded dotenv file");
         }
-        let line = line.strip_prefix("export ").unwrap_or(line).trim();
-        if let Some((key, val)) = line.split_once('=') {
-            let key = key.trim();
-            let val = val.trim();
-            // Strip matching quotes
-            let val = if val.len() >= 2
-                && ((val.starts_with('"') && val.ends_with('"'))
-                    || (val.starts_with('\'') && val.ends_with('\'')))
-            {
-                &val[1..val.len() - 1]
-            } else {
-                val
-            };
-            env.insert(key.to_string(), val.to_string());
+        Err(_) => {
+            // Missing file is the common case; nothing to load.
         }
     }
     env
@@ -380,5 +377,55 @@ mod tests {
             should_detect: false,
         });
         assert_eq!(reg.kinds(), vec!["a", "b"]);
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "coulson-test-dotenv-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_dotenv_file_missing_is_empty() {
+        let dir = temp_dir("missing");
+        let env = parse_dotenv_file(&dir.join(".coulsonrc"));
+        assert!(env.is_empty());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_dotenv_file_basic_quotes_export_comments() {
+        let dir = temp_dir("basic");
+        std::fs::write(
+            dir.join(".coulsonrc"),
+            "# comment\nexport FOO=bar\nQUOTED=\"hello world\"\n\nEMPTYLINE=ok\n",
+        )
+        .unwrap();
+        let env = parse_dotenv_file(&dir.join(".coulsonrc"));
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(env.get("QUOTED").map(String::as_str), Some("hello world"));
+        assert_eq!(env.get("EMPTYLINE").map(String::as_str), Some("ok"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_dotenv_file_interpolates_within_file() {
+        // dotenvy substitutes ${VAR} referencing earlier keys in the same file.
+        // Use a coulson-prefixed name so an ambient env var of the same name
+        // can't override the same-file value (dotenvy consults the process env
+        // and lets it win — see README), which would make this test flaky.
+        let dir = temp_dir("interp");
+        std::fs::write(
+            dir.join(".coulsonrc"),
+            "COULSON_RC_TEST_BASE=https://x\nURL=${COULSON_RC_TEST_BASE}/api\n",
+        )
+        .unwrap();
+        let env = parse_dotenv_file(&dir.join(".coulsonrc"));
+        assert_eq!(env.get("URL").map(String::as_str), Some("https://x/api"));
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## Summary
- Introduce a first-class `LayeredEnv` model for managed-process env. Precedence (low→high): `provider defaults < .coulson.toml [env] < env_url < .coulsonrc`. Both the merged child env and per-variable provenance derive from one fold (no double-apply, no reverse lookup). dotenv files are parsed via `dotenvy`.
- `.coulsonrc` (manual, local, gitignored override) now has the **highest** precedence; `.coulson.toml [env]` is provisioned/committed config below it.
- `PORT` is reserved to the provider / `listen_target` contract: it is stripped from `[env]`/`env_url` so the child's `$PORT` can never desync from the port Coulson proxies to.
- Add `coulson env [<app>] [--bare|--json|--preview]` to inspect a managed app's resolved environment with the winning **source** per variable. Default shows the **live running process's** actual env via a new `process.env` control RPC (stable PORT, start-time `env_url` values); `--preview` re-resolves offline.
- Providers now return framework defaults only; the daemon layers + stores the resolved env at spawn.

## Behavior changes (intentional)
- `.coulsonrc` now wins over `.coulson.toml [env]`; `env_url` now wins over `[env]`.
- `PORT` set in `[env]`/`env_url` is ignored (use `.coulsonrc` or the manifest `port`).
- dotenv values support `${VAR}` interpolation (escape a literal `$` as `\$`).

## Test plan
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` (238 passed).
- E2E (live daemon): web + worker child processes receive the correct merged env (`.coulsonrc` wins, `COULSON_MANAGED_SERVICES` stripped, `PORT` web-only); `coulson env` live/`--preview`/`--json`/`--bare`; PORT identical across repeated `coulson env` runs; stopped app → "not running" error.