### PR TITLE
ci: build macOS app on macos-26 runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     needs: check
     if: needs.check.outputs.should_build == 'true'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: macos-latest
+          - runner: macos-26
             target: aarch64-apple-darwin
             artifact: Coulson-macos-arm64
             arch: arm64
-          - runner: macos-latest
+          - runner: macos-26
             target: x86_64-apple-darwin
             artifact: Coulson-macos-x86_64
             arch: x86_64


### PR DESCRIPTION
## Summary
- Nightly macOS build crashed at `tuist generate` with `Abort trap: 6` (exit 134): `dyld: Library not loaded: @rpath/libswiftCompatibilitySpan.dylib`.
- `macos-latest` still resolves to macOS 15, whose `/usr/lib/swift` lacks that dylib, while the latest Homebrew `tuist` (4.198.1) is built against the Swift 6.2 runtime that requires it.
- Pin the Swift app build to `macos-26` (GA since 2026-02-26), which ships the Swift 6.2 OS runtime. Applied to both `nightly.yml` and `release.yml` (same latent bug).

## Test plan
- [ ] Manually `workflow_dispatch` Nightly Release after merge; confirm the macOS `build` job passes `tuist generate` + `xcodebuild`.