### PR TITLE
feat(tunnel): cap per-request body size with configurable limit

### DIFF
--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -78,6 +78,8 @@ pub struct CoulsonConfig {
     pub idle_timeout_secs: u64,
     pub link_dir: bool,
     pub inspect_max_requests: usize,
+    /// Max request body (MiB) buffered per tunnel request before returning 413.
+    pub max_tunnel_body_mb: usize,
     pub certs_dir: PathBuf,
     pub runtime_dir: PathBuf,
     pub process_backend: ProcessBackend,
@@ -118,6 +120,7 @@ impl Default for CoulsonConfig {
             idle_timeout_secs: 900,
             link_dir: false,
             inspect_max_requests: 200,
+            max_tunnel_body_mb: 100,
             certs_dir: xdg_config_home().join(format!("{DIR_NAME}/certs")),
             runtime_dir,
             process_backend: ProcessBackend::Auto,
@@ -164,6 +167,9 @@ impl CoulsonConfig {
         }
         if let Some(v) = file.inspect_max_requests {
             cfg.inspect_max_requests = v;
+        }
+        if let Some(v) = file.max_tunnel_body_mb {
+            cfg.max_tunnel_body_mb = v;
         }
         if let Some(ref v) = file.certs_dir {
             cfg.certs_dir = expand_tilde(v);
@@ -229,6 +235,12 @@ impl CoulsonConfig {
             cfg.inspect_max_requests = raw
                 .parse()
                 .with_context(|| format!("invalid COULSON_INSPECT_MAX_REQUESTS: {raw}"))?;
+        }
+
+        if let Ok(raw) = env::var("COULSON_MAX_TUNNEL_BODY_MB") {
+            cfg.max_tunnel_body_mb = raw
+                .parse()
+                .with_context(|| format!("invalid COULSON_MAX_TUNNEL_BODY_MB: {raw}"))?;
         }
 
         if let Ok(path) = env::var("COULSON_CERTS_DIR") {
@@ -345,6 +357,7 @@ struct ConfigFile {
     idle_timeout_secs: Option<u64>,
     link_dir: Option<bool>,
     inspect_max_requests: Option<usize>,
+    max_tunnel_body_mb: Option<usize>,
     certs_dir: Option<String>,
     runtime_dir: Option<String>,
     process_backend: Option<String>,
@@ -408,11 +421,41 @@ impl ConfigFile {
             idle_timeout_secs,
             link_dir,
             inspect_max_requests,
+            max_tunnel_body_mb,
             certs_dir,
             runtime_dir,
             process_backend,
             hook_timeout_secs,
             inspector
         );
+    }
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_overrides_max_tunnel_body_mb() {
+        let mut base = ConfigFile {
+            max_tunnel_body_mb: Some(100),
+            ..Default::default()
+        };
+        let dev = ConfigFile {
+            max_tunnel_body_mb: Some(512),
+            ..Default::default()
+        };
+        base.merge(dev);
+        assert_eq!(base.max_tunnel_body_mb, Some(512));
+    }
+
+    #[test]
+    fn merge_keeps_base_when_dev_field_unset() {
+        let mut base = ConfigFile {
+            max_tunnel_body_mb: Some(100),
+            ..Default::default()
+        };
+        base.merge(ConfigFile::default());
+        assert_eq!(base.max_tunnel_body_mb, Some(100));
     }
 }

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1052,6 +1052,11 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
         std::fs::remove_file(&cfg.control_socket)?;
     }
 
+    // Apply the configured tunnel request-body cap before any tunnel starts.
+    // Saturate rather than wrap/panic on an absurd config value (a wrap could
+    // silently shrink the cap instead of enlarging it).
+    tunnel::proxy::set_max_tunnel_request_body(cfg.max_tunnel_body_mb.saturating_mul(1024 * 1024));
+
     let state = build_state(&cfg)?;
 
     let startup_scan = scanner::sync_from_apps_root(&state)?;

--- a/crates/coulson/src/tunnel/proxy.rs
+++ b/crates/coulson/src/tunnel/proxy.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -18,6 +19,55 @@ const RESPONSE_META_ORIGIN: &str = r#"{"src":"origin"}"#;
 /// only enforced when this header is present. Stripped before forwarding to
 /// the backend.
 pub const VIA_TUNNEL_HEADER: &str = "x-coulson-via-tunnel";
+
+/// Maximum request body buffered per tunnel request before returning 413.
+/// Tunnel bodies are fully buffered in memory before being forwarded to the
+/// local proxy, so this caps the peak memory a single (or many concurrent)
+/// uploads can consume and prevents an unbounded-upload OOM of the daemon.
+///
+/// Configured via `CoulsonConfig::max_tunnel_body_mb` (toml `max_tunnel_body_mb`
+/// / env `COULSON_MAX_TUNNEL_BODY_MB`) and pushed here once at daemon startup by
+/// [`set_max_tunnel_request_body`]. The default (100 MiB) applies until then, so
+/// paths that never call the setter (e.g. CLI quick tunnels) stay bounded.
+static MAX_TUNNEL_REQUEST_BODY: AtomicUsize = AtomicUsize::new(100 * 1024 * 1024);
+
+/// Set the per-request tunnel body cap (bytes). Called once at daemon startup
+/// from the loaded `CoulsonConfig`.
+pub fn set_max_tunnel_request_body(bytes: usize) {
+    MAX_TUNNEL_REQUEST_BODY.store(bytes, Ordering::Relaxed);
+}
+
+/// Read the full h2 request body into memory, enforcing the configured
+/// [`MAX_TUNNEL_REQUEST_BODY`] cap. Returns `Ok(None)` if the body exceeds it
+/// (the caller should respond `413 Payload Too Large`). Flow-control capacity is
+/// released as chunks arrive, matching the unbounded path's backpressure.
+async fn collect_body_capped(body: &mut RecvStream) -> anyhow::Result<Option<Bytes>> {
+    let max = MAX_TUNNEL_REQUEST_BODY.load(Ordering::Relaxed);
+    let mut body_bytes = Vec::new();
+    while let Some(chunk) = body.data().await {
+        let chunk = chunk?;
+        body.flow_control().release_capacity(chunk.len())?;
+        if body_bytes.len() + chunk.len() > max {
+            return Ok(None);
+        }
+        body_bytes.extend_from_slice(&chunk);
+    }
+    Ok(Some(Bytes::from(body_bytes)))
+}
+
+/// Send a `413 Payload Too Large` response on the h2 stream.
+fn send_payload_too_large(
+    send_response: &mut h2::server::SendResponse<Bytes>,
+) -> anyhow::Result<()> {
+    let response = http::Response::builder()
+        .status(413)
+        .header("content-type", "text/plain")
+        .body(())
+        .unwrap();
+    let mut send_stream = send_response.send_response(response, false)?;
+    send_stream.send_data(Bytes::from_static(b"Payload Too Large"), true)?;
+    Ok(())
+}
 
 /// Proxy an HTTP request to the local Pingora proxy with a fixed Host header.
 /// Used for per-app tunnels where the backend is not a TCP port (e.g. static_dir, managed).
@@ -83,14 +133,16 @@ pub async fn proxy_to_local_with_host(
         .unwrap_or_else(|| local_host.to_string());
     append_forwarding_headers(&mut local_req, &original_host, &parts.headers);
 
-    let mut body_bytes = Vec::new();
-    while let Some(chunk) = body.data().await {
-        let chunk = chunk?;
-        body.flow_control().release_capacity(chunk.len())?;
-        body_bytes.extend_from_slice(&chunk);
-    }
+    let body_bytes = match collect_body_capped(&mut body).await? {
+        Some(b) => b,
+        None => {
+            warn!(local_host = %local_host, max = MAX_TUNNEL_REQUEST_BODY.load(Ordering::Relaxed), "tunnel request body exceeds cap; returning 413");
+            send_payload_too_large(&mut send_response)?;
+            return Ok(());
+        }
+    };
 
-    let local_req = local_req.body(http_body_util::Full::new(Bytes::from(body_bytes)))?;
+    let local_req = local_req.body(http_body_util::Full::new(body_bytes))?;
 
     let client = Client::builder(TokioExecutor::new()).build_http();
     let local_resp = match client.request(local_req).await {
@@ -246,15 +298,17 @@ pub async fn proxy_by_host(
     // Let the backend know the original tunnel host and protocol
     append_forwarding_headers(&mut local_req, original_host, &parts.headers);
 
-    // Collect body
-    let mut body_bytes = Vec::new();
-    while let Some(chunk) = body.data().await {
-        let chunk = chunk?;
-        body.flow_control().release_capacity(chunk.len())?;
-        body_bytes.extend_from_slice(&chunk);
-    }
+    // Collect body (capped to bound peak memory)
+    let body_bytes = match collect_body_capped(&mut body).await? {
+        Some(b) => b,
+        None => {
+            warn!(local_host = %local_host, max = MAX_TUNNEL_REQUEST_BODY.load(Ordering::Relaxed), "tunnel request body exceeds cap; returning 413");
+            send_payload_too_large(&mut send_response)?;
+            return Ok(());
+        }
+    };
 
-    let local_req = local_req.body(http_body_util::Full::new(Bytes::from(body_bytes)))?;
+    let local_req = local_req.body(http_body_util::Full::new(body_bytes))?;
 
     let client = Client::builder(TokioExecutor::new()).build_http();
     let local_resp = match client.request(local_req).await {


### PR DESCRIPTION
## Summary
- Both tunnel proxy paths buffered the full inbound request body into a `Vec` before forwarding, with no cap. The buffer is per-request (freed on completion, not a leak), but a single huge upload or many concurrent uploads could spike peak memory and OOM the daemon.
- Added a shared `collect_body_capped()` helper that enforces a cap while still releasing h2 flow-control capacity per chunk, returning `413 Payload Too Large` when exceeded.
- The cap is configurable: `CoulsonConfig::max_tunnel_body_mb` (default 100 MiB) via the standard default → toml `max_tunnel_body_mb` → env `COULSON_MAX_TUNNEL_BODY_MB` layering, pushed into the proxy at daemon startup. The 100 MiB default applies until then so non-daemon paths stay bounded.
- MiB→byte conversion uses `saturating_mul` (a wrap could silently shrink the cap); `max_tunnel_body_mb` is included in the debug `config.dev.toml` merge.

## Test plan
- [ ] `cargo test -p coulson merge_overrides_max_tunnel_body_mb merge_keeps_base_when_dev_field_unset` (added).
- [ ] Upload a body larger than the configured cap through a tunnel; confirm a 413 response and bounded daemon memory.