### PR TITLE
feat(process): restart a single process type via app:type addressing

### DIFF
--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -110,6 +110,15 @@ struct AppIdParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct ProcessActionParams {
+    app_id: i64,
+    /// Restart only this process type (`web` or a Procfile companion type).
+    /// Only honored by `process.restart`.
+    #[serde(default)]
+    process_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct NamedTunnelSetupParams {
     #[serde(default)]
     api_token: Option<String>,
@@ -532,7 +541,7 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
             }
         }
         "process.start" | "process.stop" | "process.restart" => {
-            let params: AppIdParams = parse_params!(req);
+            let params: ProcessActionParams = parse_params!(req);
             let app = find_app!(state, req, params.app_id);
             let (root, kind, name) = match &app.target {
                 crate::domain::BackendTarget::Managed {
@@ -545,6 +554,22 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                     );
                 }
             };
+            if let Some(ptype) = &params.process_type {
+                if req.method != "process.restart" {
+                    return render_err(
+                        req.request_id,
+                        ControlError::InvalidParams(
+                            "process_type is only supported for process.restart".to_string(),
+                        ),
+                    );
+                }
+                if !crate::process::is_valid_process_type(ptype) {
+                    return render_err(
+                        req.request_id,
+                        ControlError::InvalidParams(format!("invalid process type '{ptype}'")),
+                    );
+                }
+            }
             if req.method == "process.stop" {
                 let mut pm = state.process_manager.lock().await;
                 let killed = pm.kill_process(params.app_id).await;
@@ -556,9 +581,38 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
                     Ok(v) => v,
                     Err(e) => return internal_error(req.request_id, e.to_string()),
                 };
+            let mut pm = state.process_manager.lock().await;
+            if let Some(ptype) = &params.process_type {
+                return match pm
+                    .restart_process_type(
+                        params.app_id,
+                        &name,
+                        std::path::Path::new(&root),
+                        &kind,
+                        ptype,
+                        env_url_env,
+                    )
+                    .await
+                {
+                    Ok(listen_target) => {
+                        let listen_json = match &listen_target {
+                            crate::process::ListenTarget::Uds(path) => {
+                                json!({ "type": "uds", "path": path.to_string_lossy() })
+                            }
+                            crate::process::ListenTarget::Tcp { host, port } => {
+                                json!({ "type": "tcp", "host": host, "port": port })
+                            }
+                        };
+                        ok_response(
+                            req.request_id,
+                            json!({ "restarted": true, "listen": listen_json }),
+                        )
+                    }
+                    Err(e) => internal_error(req.request_id, e.to_string()),
+                };
+            }
             // start and restart both ensure the process is running;
             // restart kills first.
-            let mut pm = state.process_manager.lock().await;
             if req.method == "process.restart" {
                 pm.kill_process(params.app_id).await;
             }

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -367,9 +367,9 @@ enum Commands {
         /// App name or domain (omit to match CWD)
         name: Option<String>,
     },
-    /// Restart a managed process
+    /// Restart a managed process (whole group, or one type: app:worker, :worker)
     Restart {
-        /// App name or domain (omit to match CWD)
+        /// App name or domain, optionally with :type (omit name to match CWD)
         name: Option<String>,
     },
     /// Trust the Coulson CA certificate (add to macOS login keychain)
@@ -1502,9 +1502,12 @@ async fn main() -> anyhow::Result<()> {
             no_remote,
         } => run_env(cfg, name, bare, json, preview, no_remote).await,
         Commands::Ps => run_ps(cfg),
-        Commands::Start { name } => run_process_action(cfg, name, "process.start"),
-        Commands::Stop { name } => run_process_action(cfg, name, "process.stop"),
-        Commands::Restart { name } => run_process_action(cfg, name, "process.restart"),
+        Commands::Start { name } => run_process_action(cfg, name, "process.start", None),
+        Commands::Stop { name } => run_process_action(cfg, name, "process.stop", None),
+        Commands::Restart { name } => {
+            let (name, process_type) = parse_process_target(name)?;
+            run_process_action(cfg, name, "process.restart", process_type)
+        }
         Commands::Open { name } => run_open(cfg, name),
         Commands::Attach { name } => run_attach(cfg, name),
         Commands::Trust { forward, pf, force } => run_trust(cfg, forward || pf, force),
@@ -2395,15 +2398,38 @@ fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Split a `[name][:type]` restart target into its parts: `app` addresses the
+/// whole group, `app:worker` one process type, `:worker` a type of the CWD app.
+fn parse_process_target(arg: Option<String>) -> anyhow::Result<(Option<String>, Option<String>)> {
+    let Some(arg) = arg else {
+        return Ok((None, None));
+    };
+    match arg.split_once(':') {
+        None => Ok((Some(arg), None)),
+        Some((name, ptype)) => {
+            if ptype.is_empty() {
+                anyhow::bail!("missing process type after ':' in '{arg}'");
+            }
+            let name = (!name.is_empty()).then(|| name.to_string());
+            Ok((name, Some(ptype.to_string())))
+        }
+    }
+}
+
 fn run_process_action(
     cfg: CoulsonConfig,
     name: Option<String>,
     method: &str,
+    process_type: Option<String>,
 ) -> anyhow::Result<()> {
     let client = RpcClient::new(&cfg.control_socket);
     let (bare_name, app_id) = resolve_app_id(&client, &cfg, name)?;
 
-    let result = client.call(method, serde_json::json!({ "app_id": app_id }))?;
+    let mut params = serde_json::json!({ "app_id": app_id });
+    if let Some(ptype) = &process_type {
+        params["process_type"] = serde_json::json!(ptype);
+    }
+    let result = client.call(method, params)?;
 
     let action = match method {
         "process.start" => "started",
@@ -2411,10 +2437,15 @@ fn run_process_action(
         "process.restart" => "restarted",
         _ => "done",
     };
-    println!("{} {bare_name} {action}", "✓".green());
+    let display = match &process_type {
+        Some(ptype) => format!("{bare_name}:{ptype}"),
+        None => bare_name,
+    };
+    println!("{} {display} {action}", "✓".green());
 
-    // Show URLs after start/restart
-    if method != "process.stop" {
+    // Show URLs after start/restart (not after a companion-only restart —
+    // companions don't serve HTTP)
+    if method != "process.stop" && process_type.as_deref().is_none_or(|t| t == "web") {
         if let Some(app) = client
             .call("app.list", serde_json::json!({}))
             .ok()
@@ -3660,6 +3691,45 @@ fn is_pf_configured_quick(
     _listen_https: &Option<std::net::SocketAddr>,
 ) -> bool {
     false
+}
+
+#[cfg(test)]
+mod process_target_tests {
+    use super::*;
+
+    #[test]
+    fn no_arg_is_group_of_cwd_app() {
+        assert_eq!(parse_process_target(None).unwrap(), (None, None));
+    }
+
+    #[test]
+    fn bare_name_is_whole_group() {
+        assert_eq!(
+            parse_process_target(Some("myapp".into())).unwrap(),
+            (Some("myapp".into()), None)
+        );
+    }
+
+    #[test]
+    fn name_and_type() {
+        assert_eq!(
+            parse_process_target(Some("myapp:worker".into())).unwrap(),
+            (Some("myapp".into()), Some("worker".into()))
+        );
+    }
+
+    #[test]
+    fn type_only_uses_cwd_app() {
+        assert_eq!(
+            parse_process_target(Some(":worker".into())).unwrap(),
+            (None, Some("worker".into()))
+        );
+    }
+
+    #[test]
+    fn trailing_colon_is_an_error() {
+        assert!(parse_process_target(Some("myapp:".into())).is_err());
+    }
 }
 
 #[cfg(test)]

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -95,6 +95,9 @@ struct ManagedProcess {
 struct CompanionProcess {
     process_type: String,
     handle: ProcessHandle,
+    /// Companion's own spawn time — it can be restarted independently of the
+    /// primary, so its uptime is not the group's.
+    started_at: Instant,
 }
 
 struct ProcessGroup {
@@ -388,7 +391,7 @@ impl ProcessManager {
                     kind: proc.kind.clone(),
                     process_type: companion.process_type.clone(),
                     listen_address: String::new(),
-                    uptime_secs: now.duration_since(proc.started_at).as_secs(),
+                    uptime_secs: now.duration_since(companion.started_at).as_secs(),
                     idle_secs: now.duration_since(proc.last_active).as_secs(),
                     alive: c_alive,
                     backend: c_backend.to_string(),
@@ -787,6 +790,230 @@ impl ProcessManager {
         }
     }
 
+    /// Restart a single process type of a running app group: `"web"` restarts
+    /// the primary while companions keep running; any other type restarts that
+    /// companion alone. The group must already be running — starting a lone
+    /// member of a stopped app is not meaningful.
+    /// Returns the (possibly re-resolved) listen target of the primary.
+    pub async fn restart_process_type(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        process_type: &str,
+        env_url_env: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<ListenTarget> {
+        if !self.processes.contains_key(&app_id) {
+            anyhow::bail!("{name} is not running; use `coulson restart {name}` to start it");
+        }
+        if process_type == "web" {
+            if self
+                .processes
+                .get(&app_id)
+                .is_some_and(|g| g.companions.is_empty())
+            {
+                // No companions to preserve — identical to a group restart.
+                self.kill_process(app_id).await;
+                return self
+                    .ensure_running(app_id, name, root, kind, env_url_env)
+                    .await;
+            }
+            self.restart_primary(app_id, name, root, kind, env_url_env)
+                .await
+        } else {
+            self.restart_companion(app_id, name, root, kind, process_type, env_url_env)
+                .await?;
+            Ok(self
+                .processes
+                .get(&app_id)
+                .expect("group checked above")
+                .primary
+                .listen_target
+                .clone())
+        }
+    }
+
+    /// Kill and respawn one companion, re-resolving its Procfile entry and env
+    /// so config edits take effect. Also (re)starts a configured companion that
+    /// died or failed to spawn with the group.
+    async fn restart_companion(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        process_type: &str,
+        env_url_env: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<()> {
+        let (_spec, app_dir, _prov_name, companion_types, manifest, coulsonrc) =
+            self.resolve_spec(app_id, name, root, kind)?;
+
+        let running = self
+            .processes
+            .get(&app_id)
+            .is_some_and(|g| g.companions.iter().any(|c| c.process_type == process_type));
+        if !running && !companion_types.iter().any(|t| t == process_type) {
+            let mut available = vec!["web".to_string()];
+            available.extend(companion_types);
+            anyhow::bail!(
+                "unknown process type '{process_type}' for {name}; available: {}",
+                available.join(", ")
+            );
+        }
+
+        if let Some(group) = self.processes.get_mut(&app_id) {
+            if let Some(pos) = group
+                .companions
+                .iter()
+                .position(|c| c.process_type == process_type)
+            {
+                info!(app_id, process_type, "restarting companion process");
+                let old = group.companions.remove(pos);
+                kill_handle(old.handle).await;
+            }
+        }
+
+        let log_dir = resolve_log_dir(&manifest, root, &app_dir);
+        std::fs::create_dir_all(&log_dir).ok();
+        let log_tx = self.log_tx.clone();
+        let types = [process_type.to_string()];
+        let spawned = self.spawn_companions(
+            app_id,
+            name,
+            root,
+            kind,
+            &types,
+            &app_dir,
+            &manifest,
+            env_url_env.as_ref(),
+            &log_dir,
+            &log_tx,
+            &coulsonrc,
+        );
+        if spawned.is_empty() {
+            anyhow::bail!(
+                "failed to start {process_type} for {name} (see {})",
+                process_log_path(&log_dir, process_type).display()
+            );
+        }
+        self.processes
+            .get_mut(&app_id)
+            .expect("group checked by caller")
+            .companions
+            .extend(spawned);
+        Ok(())
+    }
+
+    /// Kill and respawn only the primary, keeping companions running. Only
+    /// reached for groups that have companions (procfile — never docker). If
+    /// the respawn fails the group is gone, so the orphaned companions are
+    /// killed too rather than leaked.
+    async fn restart_primary(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        env_url_env: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<ListenTarget> {
+        let group = self
+            .processes
+            .remove(&app_id)
+            .expect("group checked by caller");
+        info!(app_id, "restarting primary process, keeping companions");
+        kill_handle(group.primary.handle).await;
+        cleanup_listen_target(&group.primary.listen_target);
+        self.fire_hook(HookEvent::AppStop, app_id, &group.name, &group.root, kind);
+
+        match self
+            .spawn_primary(app_id, name, root, kind, env_url_env)
+            .await
+        {
+            Ok((primary, idle_timeout)) => {
+                let listen_target = primary.listen_target.clone();
+                self.processes.insert(
+                    app_id,
+                    ProcessGroup {
+                        primary,
+                        companions: group.companions,
+                        name: name.to_string(),
+                        root: root.to_path_buf(),
+                        idle_timeout,
+                    },
+                );
+                Ok(listen_target)
+            }
+            Err(e) => {
+                for companion in group.companions {
+                    kill_handle(companion.handle).await;
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Resolve and spawn the primary (non-docker), waiting for readiness.
+    /// The spawn half of `ensure_running`, minus companions and group insert.
+    async fn spawn_primary(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        env_url_env: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<(ManagedProcess, Option<Duration>)> {
+        let (mut spec, app_dir, prov_name, _companion_types, manifest, coulsonrc) =
+            self.resolve_spec(app_id, name, root, kind)?;
+        let resolved_env =
+            apply_and_capture_env(&mut spec, &manifest, env_url_env.as_ref(), &coulsonrc, root);
+
+        let log_dir = resolve_log_dir(&manifest, root, &app_dir);
+        std::fs::create_dir_all(&log_dir).ok();
+        let log_path = process_log_path(&log_dir, "web");
+
+        info!(
+            app_id,
+            kind,
+            listen = %listen_target_display(&spec.listen_target),
+            root = %root.display(),
+            "starting managed process via {prov_name} provider",
+        );
+        self.fire_hook(HookEvent::AppStart, app_id, name, root, kind);
+        cleanup_listen_target(&spec.listen_target);
+
+        let handle = self.spawn_process(
+            name,
+            &spec,
+            &log_path,
+            &app_dir,
+            &self.log_tx.clone(),
+            app_id,
+            "web",
+        )?;
+
+        if let Err(e) = wait_for_ready(&spec.listen_target, Duration::from_secs(30)).await {
+            log_tail(&log_path, name);
+            kill_handle(handle).await;
+            return Err(e);
+        }
+        self.fire_hook(HookEvent::AppReady, app_id, name, root, kind);
+
+        let now = Instant::now();
+        Ok((
+            ManagedProcess {
+                handle,
+                listen_target: spec.listen_target.clone(),
+                started_at: now,
+                last_active: now,
+                kind: kind.to_string(),
+                ready: true,
+                resolved_env,
+            },
+            manifest_idle_timeout(&manifest),
+        ))
+    }
+
     pub fn mark_active(&mut self, app_id: i64) {
         if let Some(group) = self.processes.get_mut(&app_id) {
             group.primary.last_active = Instant::now();
@@ -1062,6 +1289,7 @@ impl ProcessManager {
                             companions.push(CompanionProcess {
                                 process_type: ptype.clone(),
                                 handle,
+                                started_at: Instant::now(),
                             });
                         }
                         Err(e) => {


### PR DESCRIPTION
## Summary
- `coulson restart` now accepts `[name][:type]`: `app` (whole group, unchanged), `app:worker` / `:worker` (one companion), `app:web` / `:web` (primary only, companions kept). Name omitted → CWD app, as before.
- Companion restart re-resolves its Procfile entry and env, so config edits take effect; it can also (re)start a configured companion that died or failed to spawn. Unknown types and stopped apps get clear errors.
- `process.restart` RPC gains an optional `process_type` param; `start`/`stop` reject it — per-type stop/start would need per-member desired state the group model doesn't have.
- `CompanionProcess` gets its own `started_at` so `coulson ps` UPTIME is correct for an individually restarted companion.

## Open questions (why draft)
- Per-type restart pokes a hole in the group-atomic lifecycle: an individually restarted worker is still killed by group idle-reap / primary crash recovery; `:web` restart fires `app_stop` while the app is arguably still up, companion restarts fire no hooks at all; env can skew between members after a partial restart. Scope may shrink to companion-only (`:web` dropped) — under discussion.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (248 passed)
- [x] Manual smoke against a live daemon (direct backend, Procfile web+worker): `restart app:worker` / `:worker` bounce only the worker; `restart app:web` bounces only the primary, routing follows the re-allocated port (curl 200); unknown type and stopped-app paths error cleanly.