### PR TITLE
fix: harden app deletion, scan, and process lifecycle invariants

### DIFF
--- a/crates/coulson/src/control/mod.rs
+++ b/crates/coulson/src/control/mod.rs
@@ -477,11 +477,8 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
         }
         "app.delete" => {
             let params: AppIdParams = parse_params!(req);
-            // Stop managed process before deleting
-            let mut pm = state.process_manager.lock().await;
-            pm.kill_process(params.app_id).await;
-            drop(pm);
             service::app_delete(state, params.app_id)
+                .await
                 .map(|_| json!({ "deleted": true }))
                 .map_err(ControlError::from)
         }
@@ -506,6 +503,7 @@ async fn dispatch_request(req: RequestEnvelope, state: &SharedState) -> Response
             Ok(json!({ "notified": true }))
         }
         "apps.scan" => service::apps_scan(state)
+            .await
             .map(|stats| json!({ "scan": stats }))
             .map_err(ControlError::from),
         "process.list" => {

--- a/crates/coulson/src/dashboard/handlers.rs
+++ b/crates/coulson/src/dashboard/handlers.rs
@@ -315,7 +315,7 @@ pub async fn action_toggle_lan_access(
 }
 
 pub async fn action_scan(State(state): State<DashboardState>) -> Response {
-    let stats = service::apps_scan(&state.shared);
+    let stats = service::apps_scan(&state.shared).await;
 
     let port = state.shared.listen_http.port();
     let all = state.shared.store.list_all().unwrap_or_default();
@@ -430,7 +430,7 @@ pub async fn action_delete(
         Ok(app) => app,
         Err(_) => return html_response(StatusCode::NOT_FOUND, "Not found".to_string()),
     };
-    if let Err(e) = service::app_delete(&state.shared, app.id.0) {
+    if let Err(e) = service::app_delete(&state.shared, app.id.0).await {
         tracing::error!(error = %e, app_id = app.id.0, "delete failed");
         return html_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -460,7 +460,7 @@ pub async fn action_delete_redirect(
     Path(id): Path<String>,
 ) -> Response {
     if let Ok(app) = service::app_get_by_name(&state.shared, &id) {
-        if let Err(e) = service::app_delete(&state.shared, app.id.0) {
+        if let Err(e) = service::app_delete(&state.shared, app.id.0).await {
             tracing::error!(error = %e, app_id = app.id.0, "delete failed");
             return html_response(
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/coulson/src/domain/mod.rs
+++ b/crates/coulson/src/domain/mod.rs
@@ -156,6 +156,14 @@ pub struct AppSpec {
     pub cors_enabled: bool,
     pub force_https: bool,
     pub basic_auth_user: Option<String>,
+    /// Serialized as the boolean `basic_auth_pass_set`: `AppSpec` flows out
+    /// through control RPC responses, and the password itself must never
+    /// leave the daemon. In-daemon consumers read the field directly.
+    #[serde(
+        rename = "basic_auth_pass_set",
+        serialize_with = "ser_secret_is_set",
+        skip_deserializing
+    )]
     pub basic_auth_pass: Option<String>,
     pub spa_rewrite: bool,
     pub listen_port: Option<u16>,
@@ -165,14 +173,38 @@ pub struct AppSpec {
     pub app_tunnel_id: Option<String>,
     pub app_tunnel_domain: Option<String>,
     pub app_tunnel_dns_id: Option<String>,
+    /// Serialized as the boolean `app_tunnel_creds_set` — the JSON contains
+    /// the Cloudflare tunnel secret; RPC clients only need to know whether
+    /// saved credentials exist (tunnel mode auto-inference).
+    #[serde(
+        rename = "app_tunnel_creds_set",
+        serialize_with = "ser_secret_is_set",
+        skip_deserializing
+    )]
     pub app_tunnel_creds: Option<String>,
     pub inspect_enabled: bool,
     pub lan_access: bool,
     pub cname: Option<String>,
     pub fs_entry: Option<String>,
+    /// Per-app hook configuration from `.coulson.toml`, persisted on the row
+    /// so every row snapshot carries the hooks of that app generation.
+    /// Never serialized: `AppSpec` flows out through control RPC responses
+    /// (`app.list`/`app.get`), and hook shell commands / webhook URLs can
+    /// carry credentials. In-daemon consumers read the field directly.
+    #[serde(skip)]
+    pub hooks: Option<crate::hooks::AppHooksConfig>,
     pub enabled: bool,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
+}
+
+/// Serialize a secret field as a presence boolean — the value itself must
+/// never appear in any serialized form of `AppSpec`.
+fn ser_secret_is_set<S: serde::Serializer>(
+    value: &Option<String>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_bool(value.is_some())
 }
 
 /// Runtime context needed to build URLs for an app.

--- a/crates/coulson/src/hooks/mod.rs
+++ b/crates/coulson/src/hooks/mod.rs
@@ -1,15 +1,11 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
-use parking_lot::RwLock;
 use serde::Deserialize;
 use tokio::process::Command;
 use tracing::{debug, error, info, warn};
 
 use crate::domain::{BackendTarget, UrlContext};
-use crate::store::AppRepository;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookEvent {
@@ -55,11 +51,10 @@ pub struct HookContext {
 
 /// Shared factory for building `HookContext` from app data or minimal process info.
 ///
-/// Encapsulates the port/suffix/store context that was previously duplicated
+/// Encapsulates the port/suffix context that was previously duplicated
 /// across `service.rs::hook_context_for_app` and `process/mod.rs::fire_hook`.
 #[derive(Clone)]
 pub struct HookContextFactory {
-    store: Arc<AppRepository>,
     http_port: u16,
     https_port: Option<u16>,
     use_default_http_port: bool,
@@ -69,7 +64,6 @@ pub struct HookContextFactory {
 
 impl HookContextFactory {
     pub fn new(
-        store: Arc<AppRepository>,
         http_port: u16,
         https_port: Option<u16>,
         use_default_http_port: bool,
@@ -77,7 +71,6 @@ impl HookContextFactory {
         domain_suffix: String,
     ) -> Self {
         Self {
-            store,
             http_port,
             https_port,
             use_default_http_port,
@@ -118,8 +111,11 @@ impl HookContextFactory {
         }
     }
 
-    /// Build context from minimal process info, enriching via store lookup.
-    /// Falls back to empty domain/urls when the app is not found in the store.
+    /// Context for a process-lifecycle event. Route/URL/tunnel fields come
+    /// from `row` — the caller's single row snapshot, so context and hook
+    /// config always describe the same generation of the app — while the
+    /// process identity (name/root/kind) comes from the group that actually
+    /// ran, which can predate an in-place row rewrite.
     pub fn context_for_process(
         &self,
         event: HookEvent,
@@ -127,8 +123,9 @@ impl HookContextFactory {
         name: &str,
         root: &Path,
         kind: &str,
+        row: Option<&crate::domain::AppSpec>,
     ) -> HookContext {
-        let (domain, app_urls, tunnel_url) = if let Ok(Some(app)) = self.store.get_by_id(app_id) {
+        let (domain, app_urls, tunnel_url) = if let Some(app) = row {
             let url_ctx = self.url_context();
             let urls = app.urls(&url_ctx);
             (Some(app.domain.0.clone()), urls, app.tunnel_url.clone())
@@ -150,7 +147,10 @@ impl HookContextFactory {
 }
 
 /// Per-app hook configuration parsed from `.coulson.toml` `[hooks]` section.
-#[derive(Debug, Clone, Deserialize)]
+/// Persisted as JSON in the app's store row — the row is the single source of
+/// truth, so every snapshot of a row (delete/prune RETURNING, reads) carries
+/// the hook configuration that belongs to that exact generation of the app.
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct AppHooksConfig {
     #[serde(default)]
     pub skip_global: bool,
@@ -189,7 +189,7 @@ impl AppHooksConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct HookActionConfig {
     pub run: Option<String>,
     pub webhook: Option<String>,
@@ -199,7 +199,6 @@ pub struct HookManager {
     hooks_dir: PathBuf,
     timeout: Duration,
     http_client: reqwest::Client,
-    app_hooks: RwLock<HashMap<i64, AppHooksConfig>>,
 }
 
 impl HookManager {
@@ -211,40 +210,17 @@ impl HookManager {
                 .timeout(Duration::from_secs(10))
                 .build()
                 .unwrap_or_default(),
-            app_hooks: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Register per-app hooks from `.coulson.toml` (called during scan).
-    pub fn register_app_hooks(&self, app_id: i64, config: AppHooksConfig) {
-        self.app_hooks.write().insert(app_id, config);
-    }
-
-    /// Remove per-app hooks (called when app is deleted).
-    pub fn unregister_app_hooks(&self, app_id: i64) {
-        self.app_hooks.write().remove(&app_id);
-    }
-
-    /// Clear all per-app hooks (called before re-scanning to avoid stale entries).
-    pub fn clear_all_app_hooks(&self) {
-        self.app_hooks.write().clear();
-    }
-
-    /// Snapshot and remove per-app hooks for the given app (for use before deletion).
-    pub fn take_app_hooks(&self, app_id: i64) -> Option<AppHooksConfig> {
-        self.app_hooks.write().remove(&app_id)
-    }
-
-    /// Main entry point: fire global + per-app hooks for the given event.
+    /// Fire global hooks only. Per-app hooks live on the app's store row;
+    /// emitters that have (or destroyed) a row pass its config via
+    /// `fire_with_hooks` — there is no shared registry to look up or race.
     pub async fn fire(&self, ctx: &HookContext) {
-        let app_hooks = ctx.app_id.and_then(|id| {
-            let map = self.app_hooks.read();
-            map.get(&id).cloned()
-        });
-        self.fire_with_hooks(ctx, app_hooks.as_ref()).await;
+        self.fire_with_hooks(ctx, None).await;
     }
 
-    /// Fire with an explicit per-app hooks snapshot (avoids shared table lookup).
+    /// Fire global + per-app hooks with the caller's own hooks snapshot.
     pub async fn fire_with_hooks(&self, ctx: &HookContext, app_hooks: Option<&AppHooksConfig>) {
         let event_name = ctx.event.as_str();
 
@@ -263,11 +239,11 @@ impl HookManager {
                 }
                 if let Some(ref url) = action.webhook {
                     let payload = build_webhook_payload(ctx);
-                    let url = url.clone();
-                    let client = self.http_client.clone();
-                    tokio::spawn(async move {
-                        fire_webhook(&client, &url, &payload).await;
-                    });
+                    // Awaited inline (the client has a 10s timeout) so callers
+                    // that sequence lifecycle events — deletion fires AppStop
+                    // strictly before AppRemove — order webhook delivery too,
+                    // not just shell actions.
+                    fire_webhook(&self.http_client, url, &payload).await;
                 }
             }
         }
@@ -304,7 +280,14 @@ impl HookManager {
     /// Execute a shell command with hook environment variables.
     async fn fire_shell(&self, cmd: &str, ctx: &HookContext) {
         let event_name = ctx.event.as_str();
-        let cwd = ctx.app_root.clone().unwrap_or_else(|| PathBuf::from("."));
+        // The app root may already be gone when the hook fires — `app_stop`
+        // for a deleted/pruned app is exactly the cleanup case — and spawning
+        // with a missing cwd fails with ENOENT. Fall back to the daemon cwd;
+        // `COULSON_APP_ROOT` still carries the original path.
+        let cwd = match ctx.app_root {
+            Some(ref root) if root.is_dir() => root.clone(),
+            _ => PathBuf::from("."),
+        };
 
         let mut command = Command::new("sh");
         command.arg("-c").arg(cmd);

--- a/crates/coulson/src/hooks/mod.rs
+++ b/crates/coulson/src/hooks/mod.rs
@@ -484,4 +484,46 @@ webhook = "https://hooks.example.com/ready"
         let ar = config.app_ready.as_ref().unwrap();
         assert_eq!(ar.run.as_deref(), Some("mise run db:migrate"));
     }
+
+    #[test]
+    fn process_context_keeps_provider_kind_with_normalized_snapshot() {
+        let base = std::env::temp_dir().join(format!(
+            "coulson-test-hook-provider-kind-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let repo =
+            crate::store::AppRepository::new(&base.join("state.sqlite"), "coulson.local").unwrap();
+        repo.init_schema().unwrap();
+        let domain = crate::domain::DomainName("dock.coulson.local".to_string());
+        let root = base.join("dock");
+        let (app, _) = repo
+            .upsert_scanned_managed(
+                "dock",
+                &domain,
+                root.to_str().unwrap(),
+                "docker",
+                true,
+                "apps_root",
+                "dock",
+                None,
+            )
+            .unwrap();
+        assert_eq!(app.kind, crate::domain::AppKind::Container);
+
+        let factory = HookContextFactory::new(80, None, true, false, "coulson.local".to_string());
+        let ctx = factory.context_for_process(
+            HookEvent::AppStop,
+            app.id.0,
+            "dock",
+            &root,
+            "docker",
+            Some(&app),
+        );
+        assert_eq!(ctx.app_kind.as_deref(), Some("docker"));
+        assert_eq!(ctx.app_domain.as_deref(), Some("dock.coulson.local"));
+        assert_eq!(ctx.app_root.as_deref(), Some(root.as_path()));
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1311,11 +1311,28 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
         }
     });
 
-    let reaper_pm = state.process_manager.clone();
+    let reaper_state = state.clone();
     let reaper_task = tokio::spawn(async move {
         loop {
             sleep(Duration::from_secs(30)).await;
-            let mut pm = reaper_pm.lock().await;
+            // Reconcile against the store: apps can be deleted behind the
+            // ProcessManager's back (scanner prune, out-of-process `coulson
+            // scan`). On a store error skip reconciling — an empty set would
+            // read as "kill everything".
+            let live_app_ids = match reaper_state.store.list_filtered(None, None) {
+                Ok(apps) => Some(apps.iter().map(|a| a.id.0).collect()),
+                Err(err) => {
+                    error!(error = %err, "skipping orphan reconcile: store unavailable");
+                    None
+                }
+            };
+            let mut pm = reaper_state.process_manager.lock().await;
+            if let Some(live_app_ids) = live_app_ids {
+                let orphaned = pm.kill_orphans(&live_app_ids).await;
+                if orphaned > 0 {
+                    info!(orphaned, "reaped orphaned managed processes");
+                }
+            }
             let reaped = pm.reap_idle().await;
             if reaped > 0 {
                 info!(reaped, "reaped idle managed processes");
@@ -2353,10 +2370,12 @@ fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {
                 .get("app_id")
                 .map(|v| v.to_string().trim_matches('"').to_string())
                 .unwrap_or_default();
+            // A process whose app is gone from the store (deleted app dir,
+            // `coulson rm`) lingers until the orphan reaper's next tick.
             let (name, _domain) = app_map
                 .get(&app_id)
                 .cloned()
-                .unwrap_or_else(|| (app_id.to_string(), String::new()));
+                .unwrap_or_else(|| (format!("#{app_id} (removed)"), String::new()));
             let pid = p.get("pid").and_then(|v| v.as_u64()).unwrap_or(0);
             let kind_raw = p.get("kind").and_then(|v| v.as_str()).unwrap_or("unknown");
             let kind = match kind_raw {

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -143,6 +143,9 @@ pub struct SharedState {
     pub inspector_password: Option<String>,
     /// Cached privileged-port status with TTL to avoid per-request disk I/O.
     forward_cache: Arc<Mutex<(bool, std::time::Instant)>>,
+    /// Serializes apps-root scans (manual RPC scan vs fs-watcher scan): the
+    /// scan's store upserts + prune + hook-map swap must not interleave.
+    pub scan_mutex: Arc<Mutex<()>>,
 }
 
 impl SharedState {
@@ -187,7 +190,6 @@ impl SharedState {
     /// Uses the cached PF-forwarding check so URLs reflect privileged-port status.
     pub fn hook_factory(&self) -> HookContextFactory {
         HookContextFactory::new(
-            Arc::clone(&self.store),
             self.listen_http.port(),
             self.listen_https.map(|a| a.port()),
             self.use_default_http_port(),
@@ -508,7 +510,6 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
                 .unwrap_or(false)
             || is_pf_configured_quick(&cfg.listen_http, &cfg.listen_https));
     let pm_hook_factory = HookContextFactory::new(
-        Arc::clone(&store),
         cfg.listen_http.port(),
         cfg.listen_https.map(|a| a.port()),
         pm_use_default_http,
@@ -523,6 +524,7 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
         hook_manager: Arc::clone(&hook_manager),
         hook_factory: pm_hook_factory,
         log_tx: log_tx.clone(),
+        store: Arc::clone(&store),
     });
 
     Ok(SharedState {
@@ -557,6 +559,7 @@ fn build_state(cfg: &CoulsonConfig) -> anyhow::Result<SharedState> {
             is_forward_configured_for_port(cfg.listen_http.port()) || is_pf_configured(cfg),
             std::time::Instant::now(),
         ))),
+        scan_mutex: Arc::new(Mutex::new(())),
     })
 }
 
@@ -1261,6 +1264,10 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
         while rx.recv().await.is_some() {
             match scanner::sync_from_apps_root(&watch_state) {
                 Ok(result) => {
+                    // Teardown first — the pruned rows and hook registrations
+                    // are already gone, so it must not depend on the fallible
+                    // steps below succeeding.
+                    service::teardown_pruned_apps(&watch_state, &result.pruned_apps).await;
                     if let Err(err) =
                         runtime::write_scan_warnings(&watch_state.scan_warnings_path, &result.stats)
                     {
@@ -1317,20 +1324,30 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
             sleep(Duration::from_secs(30)).await;
             // Reconcile against the store: apps can be deleted behind the
             // ProcessManager's back (scanner prune, out-of-process `coulson
-            // scan`). On a store error skip reconciling — an empty set would
-            // read as "kill everything".
-            let live_app_ids = match reaper_state.store.list_filtered(None, None) {
-                Ok(apps) => Some(apps.iter().map(|a| a.id.0).collect()),
+            // scan`). The store is read while holding the PM lock — any group
+            // in the map was inserted before the lock was acquired, and an app
+            // row always exists before its process starts, so a freshly
+            // created app can never be misread as an orphan. On a store error
+            // skip reconciling — an empty set would read as "kill everything".
+            let mut pm = reaper_state.process_manager.lock().await;
+            match reaper_state.store.list_filtered(None, None) {
+                Ok(apps) => {
+                    let live_apps: HashMap<i64, (String, std::path::PathBuf, String)> = apps
+                        .into_iter()
+                        .filter_map(|a| match a.target {
+                            BackendTarget::Managed {
+                                root, name, kind, ..
+                            } => Some((a.id.0, (name, std::path::PathBuf::from(root), kind))),
+                            _ => None,
+                        })
+                        .collect();
+                    let orphaned = pm.kill_orphans(&live_apps).await;
+                    if orphaned > 0 {
+                        info!(orphaned, "reaped orphaned managed processes");
+                    }
+                }
                 Err(err) => {
                     error!(error = %err, "skipping orphan reconcile: store unavailable");
-                    None
-                }
-            };
-            let mut pm = reaper_state.process_manager.lock().await;
-            if let Some(live_app_ids) = live_app_ids {
-                let orphaned = pm.kill_orphans(&live_app_ids).await;
-                if orphaned > 0 {
-                    info!(orphaned, "reaped orphaned managed processes");
                 }
             }
             let reaped = pm.reap_idle().await;
@@ -2007,7 +2024,8 @@ fn run_rm_by_name(cfg: &CoulsonConfig, name: &str) -> anyhow::Result<()> {
     let mut removed_db = false;
 
     // Check apps_root for file/symlink
-    let removed_file = scanner::remove_app_fs_entry(&cfg.apps_root, bare_name);
+    let removed_file =
+        scanner::remove_app_fs_entry(&cfg.apps_root, bare_name) == scanner::FsEntryRemoval::Removed;
 
     // Best-effort RPC delete
     let client = RpcClient::new(&cfg.control_socket);
@@ -2320,9 +2338,12 @@ fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Build app_id → (name, domain) map from app.list
-    let app_map: HashMap<String, (String, String)> =
-        if let Ok(app_result) = client.call("app.list", serde_json::json!({})) {
+    // Build app_id → (name, domain) map from app.list. `None` means the query
+    // itself failed — in that case no claims about removal can be made.
+    let app_map: Option<HashMap<String, (String, String)>> = client
+        .call("app.list", serde_json::json!({}))
+        .ok()
+        .and_then(|app_result| {
             app_result
                 .get("apps")
                 .and_then(|v| v.as_array())
@@ -2342,10 +2363,7 @@ fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {
                         })
                         .collect()
                 })
-                .unwrap_or_default()
-        } else {
-            HashMap::new()
-        };
+        });
 
     #[derive(Tabled)]
     struct PsRow {
@@ -2371,11 +2389,15 @@ fn run_ps(cfg: CoulsonConfig) -> anyhow::Result<()> {
                 .map(|v| v.to_string().trim_matches('"').to_string())
                 .unwrap_or_default();
             // A process whose app is gone from the store (deleted app dir,
-            // `coulson rm`) lingers until the orphan reaper's next tick.
-            let (name, _domain) = app_map
-                .get(&app_id)
-                .cloned()
-                .unwrap_or_else(|| (format!("#{app_id} (removed)"), String::new()));
+            // `coulson rm`) lingers until the orphan reaper's next tick — but
+            // only claim "removed" when the app query itself succeeded.
+            let (name, _domain) = match &app_map {
+                Some(map) => map
+                    .get(&app_id)
+                    .cloned()
+                    .unwrap_or_else(|| (format!("#{app_id} (removed)"), String::new())),
+                None => (app_id.to_string(), String::new()),
+            };
             let pid = p.get("pid").and_then(|v| v.as_u64()).unwrap_or(0);
             let kind_raw = p.get("kind").and_then(|v| v.as_str()).unwrap_or("unknown");
             let kind = match kind_raw {
@@ -2929,10 +2951,12 @@ fn run_tunnel(cfg: CoulsonConfig, action: TunnelCommands) -> anyhow::Result<()> 
                     // 2. global named tunnel is connected → global (expose via it)
                     // 3. otherwise → quick
                     let app_info = find_app_json(&client, app_id)?;
+                    // The RPC DTO exposes only a presence boolean — the
+                    // credential JSON itself never leaves the daemon.
                     let has_creds = app_info
-                        .get("app_tunnel_creds")
-                        .and_then(|v| v.as_str())
-                        .is_some();
+                        .get("app_tunnel_creds_set")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
                     if has_creds {
                         TunnelMode::Named
                     } else {

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1756,7 +1756,7 @@ fn run_add_directory_inner(
     };
 
     let registry = process::default_registry();
-    if let Some((_provider, detected)) = registry.detect(cwd, manifest.as_ref()) {
+    if let Some((_provider, detected)) = registry.detect(cwd, manifest.as_ref())? {
         std::fs::create_dir_all(&cfg.apps_root)?;
         #[cfg(unix)]
         std::os::unix::fs::symlink(cwd, &link_path).with_context(|| {

--- a/crates/coulson/src/process/asgi.rs
+++ b/crates/coulson/src/process/asgi.rs
@@ -4,7 +4,9 @@ use anyhow::bail;
 use serde_json::Value;
 use tracing::warn;
 
-use super::provider::{DetectedApp, ListenTarget, ManagedApp, ProcessProvider, ProcessSpec};
+use super::provider::{
+    detection_path_exists, DetectedApp, ListenTarget, ManagedApp, ProcessProvider, ProcessSpec,
+};
 
 pub struct AsgiProvider;
 
@@ -17,28 +19,30 @@ impl ProcessProvider for AsgiProvider {
         "Python ASGI"
     }
 
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp> {
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> anyhow::Result<Option<DetectedApp>> {
         // If manifest explicitly says kind=asgi, trust it.
         if let Some(m) = manifest {
             if m.get("kind").and_then(|v| v.as_str()) == Some("asgi") {
-                return Some(DetectedApp {
+                return Ok(Some(DetectedApp {
                     kind: "asgi".into(),
                     meta: Value::Null,
-                });
+                }));
             }
         }
 
         // Convention-based detection:
         // has (app.py || main.py) AND (pyproject.toml || requirements.txt)
-        let has_entry = dir.join("app.py").exists() || dir.join("main.py").exists();
-        let has_deps = dir.join("pyproject.toml").exists() || dir.join("requirements.txt").exists();
+        let has_entry = detection_path_exists(&dir.join("app.py"))?
+            || detection_path_exists(&dir.join("main.py"))?;
+        let has_deps = detection_path_exists(&dir.join("pyproject.toml"))?
+            || detection_path_exists(&dir.join("requirements.txt"))?;
         if has_entry && has_deps {
-            Some(DetectedApp {
+            Ok(Some(DetectedApp {
                 kind: "asgi".into(),
                 meta: Value::Null,
-            })
+            }))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -178,7 +182,7 @@ mod tests {
         fs::write(root.join("app.py"), "").unwrap();
         fs::write(root.join("requirements.txt"), "").unwrap();
         let provider = AsgiProvider;
-        let detected = provider.detect(&root, None);
+        let detected = provider.detect(&root, None).expect("detection succeeds");
         assert!(detected.is_some());
         assert_eq!(detected.unwrap().kind, "asgi");
         fs::remove_dir_all(&root).ok();
@@ -189,7 +193,9 @@ mod tests {
         let root = temp_app_dir("detect-asgi-manifest");
         let provider = AsgiProvider;
         let manifest = serde_json::json!({ "kind": "asgi" });
-        let detected = provider.detect(&root, Some(&manifest));
+        let detected = provider
+            .detect(&root, Some(&manifest))
+            .expect("detection succeeds");
         assert!(detected.is_some());
         fs::remove_dir_all(&root).ok();
     }
@@ -199,7 +205,10 @@ mod tests {
         let root = temp_app_dir("detect-asgi-nomatch");
         fs::write(root.join("index.html"), "").unwrap();
         let provider = AsgiProvider;
-        assert!(provider.detect(&root, None).is_none());
+        assert!(provider
+            .detect(&root, None)
+            .expect("detection succeeds")
+            .is_none());
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/coulson/src/process/docker.rs
+++ b/crates/coulson/src/process/docker.rs
@@ -4,7 +4,8 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::provider::{
-    resolve_port, DetectedApp, ListenTarget, ManagedApp, ProcessProvider, ProcessSpec,
+    detection_path_exists, resolve_port, DetectedApp, ListenTarget, ManagedApp, ProcessProvider,
+    ProcessSpec,
 };
 
 /// Compose files in priority order.
@@ -22,8 +23,13 @@ const COMPOSE_FILES: &[&str] = &[
 pub struct DockerProvider;
 
 /// Find the first matching compose file in the directory.
-fn find_compose_file(dir: &Path) -> Option<&'static str> {
-    COMPOSE_FILES.iter().find(|f| dir.join(f).exists()).copied()
+fn find_compose_file(dir: &Path) -> anyhow::Result<Option<&'static str>> {
+    for file in COMPOSE_FILES {
+        if detection_path_exists(&dir.join(file))? {
+            return Ok(Some(file));
+        }
+    }
+    Ok(None)
 }
 
 /// Find the `docker` binary in PATH.
@@ -57,7 +63,7 @@ fn determine_compose_file(dir: &Path, manifest: Option<&Value>) -> anyhow::Resul
             dir.display()
         );
     }
-    find_compose_file(dir)
+    find_compose_file(dir)?
         .map(|s| s.to_string())
         .ok_or_else(|| {
             anyhow::anyhow!(
@@ -124,27 +130,25 @@ impl ProcessProvider for DockerProvider {
         "Docker Compose"
     }
 
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp> {
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> anyhow::Result<Option<DetectedApp>> {
         if let Some(m) = manifest {
             if m.get("kind").and_then(|v| v.as_str()) == Some("docker") {
-                let compose_file = determine_compose_file(dir, manifest)
-                    .ok()
-                    .unwrap_or_default();
-                return Some(DetectedApp {
+                let compose_file = determine_compose_file(dir, manifest)?;
+                return Ok(Some(DetectedApp {
                     kind: "docker".into(),
                     meta: serde_json::json!({ "compose_file": compose_file }),
-                });
+                }));
             }
         }
 
-        if let Some(f) = find_compose_file(dir) {
-            return Some(DetectedApp {
+        if let Some(f) = find_compose_file(dir)? {
+            return Ok(Some(DetectedApp {
                 kind: "docker".into(),
                 meta: serde_json::json!({ "compose_file": f }),
-            });
+            }));
         }
 
-        None
+        Ok(None)
     }
 
     fn resolve(&self, app: &ManagedApp) -> anyhow::Result<ProcessSpec> {
@@ -243,7 +247,7 @@ mod tests {
         let dir = temp_dir("detect-compose-yml");
         fs::write(dir.join("docker-compose.yml"), "version: '3'").unwrap();
         let p = DockerProvider;
-        let result = p.detect(&dir, None);
+        let result = p.detect(&dir, None).expect("detection succeeds");
         assert!(result.is_some());
         let meta = result.unwrap().meta;
         assert_eq!(
@@ -258,7 +262,7 @@ mod tests {
         let dir = temp_dir("detect-compose-yaml");
         fs::write(dir.join("compose.yaml"), "services:").unwrap();
         let p = DockerProvider;
-        let result = p.detect(&dir, None);
+        let result = p.detect(&dir, None).expect("detection succeeds");
         assert!(result.is_some());
         let meta = result.unwrap().meta;
         assert_eq!(
@@ -273,7 +277,7 @@ mod tests {
         let dir = temp_dir("detect-compose-yml-short");
         fs::write(dir.join("compose.yml"), "services:").unwrap();
         let p = DockerProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -283,7 +287,7 @@ mod tests {
         fs::write(dir.join("Dockerfile"), "FROM node:20").unwrap();
         let p = DockerProvider;
         assert!(
-            p.detect(&dir, None).is_none(),
+            p.detect(&dir, None).unwrap().is_none(),
             "bare Dockerfile without compose should not be detected"
         );
         fs::remove_dir_all(&dir).ok();
@@ -294,7 +298,7 @@ mod tests {
         let dir = temp_dir("detect-nomatch");
         fs::write(dir.join("app.py"), "").unwrap();
         let p = DockerProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).unwrap().is_none());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -304,7 +308,7 @@ mod tests {
         fs::write(dir.join("compose.yml"), "services:").unwrap();
         let manifest = serde_json::json!({ "kind": "docker" });
         let p = DockerProvider;
-        assert!(p.detect(&dir, Some(&manifest)).is_some());
+        assert!(p.detect(&dir, Some(&manifest)).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -314,14 +318,14 @@ mod tests {
         fs::write(dir.join("compose.yml"), "").unwrap();
         fs::write(dir.join("docker-compose.yml"), "").unwrap();
         // docker-compose.yml has higher priority
-        assert_eq!(find_compose_file(&dir), Some("docker-compose.yml"));
+        assert_eq!(find_compose_file(&dir).unwrap(), Some("docker-compose.yml"));
         fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn find_compose_file_none() {
         let dir = temp_dir("compose-none");
-        assert_eq!(find_compose_file(&dir), None);
+        assert_eq!(find_compose_file(&dir).unwrap(), None);
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -841,6 +841,25 @@ impl ProcessManager {
         to_remove.len()
     }
 
+    /// Kill process groups whose app no longer exists in the store. Apps can
+    /// be deleted without the ProcessManager hearing about it — scanner prune
+    /// after the app directory vanished, or an out-of-process `coulson scan`
+    /// writing the shared DB — so the reaper reconciles against the store as
+    /// the single source of truth. Returns the number of groups killed.
+    pub async fn kill_orphans(&mut self, live_app_ids: &std::collections::HashSet<i64>) -> usize {
+        let orphans: Vec<i64> = self
+            .processes
+            .keys()
+            .filter(|id| !live_app_ids.contains(id))
+            .copied()
+            .collect();
+        for app_id in &orphans {
+            info!(app_id, "reaping orphaned managed process (app removed)");
+            self.kill_process(*app_id).await;
+        }
+        orphans.len()
+    }
+
     /// Kill all managed processes (called on daemon shutdown).
     pub async fn shutdown_all(&mut self) {
         for (app_id, group) in self.processes.drain() {

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -551,8 +551,6 @@ impl ProcessManager {
             return Err(e);
         }
 
-        self.fire_hook(HookEvent::AppReady, app_id, name, root, kind, &app_row);
-
         let companions = self.spawn_companions(
             app_id,
             name,
@@ -569,24 +567,54 @@ impl ProcessManager {
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
         let now = Instant::now();
-        self.processes.insert(
-            app_id,
-            ProcessGroup {
-                primary: ManagedProcess {
-                    handle,
-                    listen_target: spec.listen_target.clone(),
-                    started_at: now,
-                    last_active: now,
-                    kind: kind.to_string(),
-                    ready: true,
-                    resolved_env,
-                },
-                companions,
-                name: name.to_string(),
-                root: root.to_path_buf(),
-                idle_timeout: app_idle_timeout,
-                app_snapshot: app_row,
+        let group = ProcessGroup {
+            primary: ManagedProcess {
+                handle,
+                listen_target: spec.listen_target.clone(),
+                started_at: now,
+                last_active: now,
+                kind: kind.to_string(),
+                ready: true,
+                resolved_env,
             },
+            companions,
+            name: name.to_string(),
+            root: root.to_path_buf(),
+            idle_timeout: app_idle_timeout,
+            app_snapshot: app_row,
+        };
+        let ready_snapshot = group.app_snapshot.clone();
+        if let Err((err, group)) = self.commit_process_group(app_id, name, root, kind, group) {
+            let ProcessGroup {
+                primary,
+                companions,
+                name,
+                root,
+                app_snapshot,
+                ..
+            } = *group;
+            for companion in companions {
+                kill_handle(companion.handle).await;
+            }
+            cleanup_listen_target(&primary.listen_target);
+            kill_handle(primary.handle).await;
+            self.fire_hook(
+                HookEvent::AppStop,
+                app_id,
+                &name,
+                &root,
+                kind,
+                &app_snapshot,
+            );
+            return Err(err.context("app changed while process was starting"));
+        }
+        self.fire_hook(
+            HookEvent::AppReady,
+            app_id,
+            name,
+            root,
+            kind,
+            &ready_snapshot,
         );
 
         Ok(spec.listen_target)
@@ -791,25 +819,46 @@ impl ProcessManager {
 
         let app_idle_timeout = manifest_idle_timeout(&manifest);
         let now = Instant::now();
-        self.processes.insert(
-            app_id,
-            ProcessGroup {
-                primary: ManagedProcess {
-                    handle,
-                    listen_target: spec.listen_target,
-                    started_at: now,
-                    last_active: now,
-                    kind: kind.to_string(),
-                    ready: false,
-                    resolved_env,
-                },
-                companions,
-                name: name.to_string(),
-                root: root.to_path_buf(),
-                idle_timeout: app_idle_timeout,
-                app_snapshot: app_row,
+        let group = ProcessGroup {
+            primary: ManagedProcess {
+                handle,
+                listen_target: spec.listen_target,
+                started_at: now,
+                last_active: now,
+                kind: kind.to_string(),
+                ready: false,
+                resolved_env,
             },
-        );
+            companions,
+            name: name.to_string(),
+            root: root.to_path_buf(),
+            idle_timeout: app_idle_timeout,
+            app_snapshot: app_row,
+        };
+        if let Err((err, group)) = self.commit_process_group(app_id, name, root, kind, group) {
+            let ProcessGroup {
+                primary,
+                companions,
+                name,
+                root,
+                app_snapshot,
+                ..
+            } = *group;
+            for companion in companions {
+                kill_handle(companion.handle).await;
+            }
+            cleanup_listen_target(&primary.listen_target);
+            kill_handle(primary.handle).await;
+            self.fire_hook(
+                HookEvent::AppStop,
+                app_id,
+                &name,
+                &root,
+                kind,
+                &app_snapshot,
+            );
+            return Err(err.context("app changed while process was starting"));
+        }
 
         Ok(EnsureStarted::Status(StartStatus::Starting))
     }
@@ -1001,6 +1050,16 @@ impl ProcessManager {
             .store
             .get_by_id(app_id)
             .context("store lookup before spawn")?;
+        Self::validate_app_snapshot(row, app_id, name, root, kind)
+    }
+
+    fn validate_app_snapshot(
+        row: Option<crate::domain::AppSpec>,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+    ) -> anyhow::Result<crate::domain::AppSpec> {
         let current = row.filter(|app| match &app.target {
             crate::domain::BackendTarget::Managed {
                 root: r,
@@ -1016,6 +1075,45 @@ impl ProcessManager {
                 anyhow::bail!("app {name} (id={app_id}) was removed or changed; refusing to start")
             }
         }
+    }
+
+    fn acquire_spawn_commit<'a>(
+        store: &'a crate::store::AppRepository,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+    ) -> anyhow::Result<crate::store::StoreTxn<'a>> {
+        let txn = store
+            .begin_write()
+            .context("failed to acquire spawn commit guard")?;
+        let row = txn
+            .get_by_id(app_id)
+            .context("store lookup at spawn commit")?;
+        Self::validate_app_snapshot(row, app_id, name, root, kind)?;
+        Ok(txn)
+    }
+
+    /// Atomically bridge durable desired state and the in-memory process map.
+    /// The SQLite writer guard prevents both in-process and offline scanners
+    /// from committing a rewrite/prune after validation but before the group
+    /// becomes visible to teardown/reconciliation.
+    fn commit_process_group(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        group: ProcessGroup,
+    ) -> Result<(), (anyhow::Error, Box<ProcessGroup>)> {
+        let store = self.store.clone();
+        let spawn_commit = match Self::acquire_spawn_commit(&store, app_id, name, root, kind) {
+            Ok(txn) => txn,
+            Err(err) => return Err((err, Box::new(group))),
+        };
+        self.processes.insert(app_id, group);
+        drop(spawn_commit);
+        Ok(())
     }
 
     /// Kill all managed processes (called on daemon shutdown).
@@ -3502,6 +3600,51 @@ OVERRIDE = "toml_wins"
         assert!(pm
             .validate_app_current(app.id.0, "other", &root, "procfile")
             .is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn spawn_commit_guard_serializes_offline_writer() {
+        let dir =
+            std::env::temp_dir().join(format!("coulson-test-spawn-commit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("db.sqlite");
+        let store = crate::store::AppRepository::new(&db_path, "coulson.local").unwrap();
+        store.init_schema().unwrap();
+        let root = dir.join("myapp");
+        let domain = crate::domain::DomainName("myapp.coulson.local".to_string());
+        let (app, _) = store
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                root.to_str().unwrap(),
+                "procfile",
+                true,
+                "fs",
+                "e",
+                None,
+            )
+            .unwrap();
+
+        let guard =
+            ProcessManager::acquire_spawn_commit(&store, app.id.0, "myapp", &root, "procfile")
+                .expect("spawn commit guard");
+        let offline = crate::store::AppRepository::new(&db_path, "coulson.local").unwrap();
+        let (attempt_tx, attempt_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            attempt_tx.send(()).unwrap();
+            let acquired = offline.begin_write().is_ok();
+            acquired_tx.send(acquired).unwrap();
+        });
+        attempt_rx.recv().unwrap();
+        assert!(acquired_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+        drop(guard);
+        assert!(acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap());
+        writer.join().unwrap();
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -45,6 +45,7 @@ pub struct ProcessManagerConfig {
     pub hook_manager: Arc<HookManager>,
     pub hook_factory: HookContextFactory,
     pub log_tx: broadcast::Sender<LogLine>,
+    pub store: Arc<crate::store::AppRepository>,
 }
 
 pub fn new_process_manager(cfg: ProcessManagerConfig) -> ProcessManagerHandle {
@@ -106,6 +107,19 @@ struct ProcessGroup {
     root: PathBuf,
     /// Per-app idle timeout override from `.coulson.toml`.
     idle_timeout: Option<Duration>,
+    /// The validated store row captured at the spawn commit point. Lifecycle
+    /// events for this group (stop/idle, orphan reap) are built from this
+    /// snapshot, so their route context and per-app hooks survive row
+    /// deletion — event ownership follows the group, not the row.
+    app_snapshot: crate::domain::AppSpec,
+}
+
+/// Identity and snapshot of a group removed by `kill_process_quiet`.
+pub struct StoppedGroup {
+    pub name: String,
+    pub root: PathBuf,
+    pub kind: String,
+    pub app_snapshot: crate::domain::AppSpec,
 }
 
 pub struct ProcessManager {
@@ -117,6 +131,16 @@ pub struct ProcessManager {
     hook_manager: Arc<HookManager>,
     hook_factory: HookContextFactory,
     log_tx: broadcast::Sender<LogLine>,
+    /// Desired-state source of truth: consulted before committing to a spawn
+    /// so a deleted/changed app cannot be resurrected by an in-flight request.
+    store: Arc<crate::store::AppRepository>,
+}
+
+/// Whether a tracked group still belongs to the app described by the store
+/// row. Ids alone are ambiguous (SQLite reuses row ids after deletion, and
+/// the scanner can change a row's provider kind in place).
+fn group_identity_matches(group: &ProcessGroup, name: &str, root: &Path, kind: &str) -> bool {
+    group.name == name && group.root == root && group.primary.kind == kind
 }
 
 pub enum StartStatus {
@@ -307,15 +331,29 @@ impl ProcessManager {
             hook_manager: cfg.hook_manager,
             hook_factory: cfg.hook_factory,
             log_tx: cfg.log_tx,
+            store: cfg.store,
         }
     }
 
-    fn fire_hook(&self, event: HookEvent, app_id: i64, name: &str, root: &Path, kind: &str) {
+    /// Fire a lifecycle event from the caller's row snapshot: context fields
+    /// and hook config derive from the same `AppSpec`, which the caller owns
+    /// (the group's spawn-time snapshot, or the row just validated) — so the
+    /// event neither mixes generations nor depends on the row still existing.
+    fn fire_hook(
+        &self,
+        event: HookEvent,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+        row: &crate::domain::AppSpec,
+    ) {
         let ctx = self
             .hook_factory
-            .context_for_process(event, app_id, name, root, kind);
+            .context_for_process(event, app_id, name, root, kind, Some(row));
+        let app_hooks = row.hooks.clone();
         let hm = self.hook_manager.clone();
-        tokio::spawn(async move { hm.fire(&ctx).await });
+        tokio::spawn(async move { hm.fire_with_hooks(&ctx, app_hooks.as_ref()).await });
     }
 
     /// Whether the tmux backend is active.
@@ -408,6 +446,7 @@ impl ProcessManager {
         kind: &str,
         env_url_env: Option<HashMap<String, String>>,
     ) -> anyhow::Result<ListenTarget> {
+        self.remove_stale_group(app_id, name, root, kind).await?;
         // Check if already running and alive
         if let Some(group) = self.processes.get_mut(&app_id) {
             if is_alive(&mut group.primary.handle) {
@@ -422,6 +461,8 @@ impl ProcessManager {
             kill_handle(removed.primary.handle).await;
             cleanup_listen_target(&removed.primary.listen_target);
         }
+
+        let app_row = self.validate_app_current(app_id, name, root, kind)?;
 
         let (mut spec, app_dir, prov_name, companion_types, manifest, coulsonrc) =
             self.resolve_spec(app_id, name, root, kind)?;
@@ -441,7 +482,7 @@ impl ProcessManager {
             "starting managed process via {prov_name} provider",
         );
 
-        self.fire_hook(HookEvent::AppStart, app_id, name, root, kind);
+        self.fire_hook(HookEvent::AppStart, app_id, name, root, kind, &app_row);
 
         cleanup_listen_target(&spec.listen_target);
 
@@ -510,7 +551,7 @@ impl ProcessManager {
             return Err(e);
         }
 
-        self.fire_hook(HookEvent::AppReady, app_id, name, root, kind);
+        self.fire_hook(HookEvent::AppReady, app_id, name, root, kind, &app_row);
 
         let companions = self.spawn_companions(
             app_id,
@@ -544,6 +585,7 @@ impl ProcessManager {
                 name: name.to_string(),
                 root: root.to_path_buf(),
                 idle_timeout: app_idle_timeout,
+                app_snapshot: app_row,
             },
         );
 
@@ -560,6 +602,7 @@ impl ProcessManager {
         kind: &str,
         env_url_env: Option<HashMap<String, String>>,
     ) -> anyhow::Result<EnsureStarted> {
+        self.remove_stale_group(app_id, name, root, kind).await?;
         // Check existing process state in a limited scope to avoid borrow conflicts
         enum ExistingState {
             AlreadyReady(ListenTarget),
@@ -605,7 +648,10 @@ impl ProcessManager {
                 return Ok(EnsureStarted::Status(StartStatus::Ready(target)));
             }
             Some(ExistingState::JustBecameReady(target)) => {
-                self.fire_hook(HookEvent::AppReady, app_id, name, root, kind);
+                if let Some(snapshot) = self.processes.get(&app_id).map(|g| g.app_snapshot.clone())
+                {
+                    self.fire_hook(HookEvent::AppReady, app_id, name, root, kind, &snapshot);
+                }
                 return Ok(EnsureStarted::Status(StartStatus::Ready(target)));
             }
             Some(ExistingState::StillStarting) => {
@@ -644,6 +690,8 @@ impl ProcessManager {
             None => {} // No existing process, proceed to spawn
         }
 
+        let app_row = self.validate_app_current(app_id, name, root, kind)?;
+
         // We are about to cold-start. If `env_url` is configured but we have no
         // prefetched env (the process looked alive when the prefetch was skipped
         // but has since exited), bail to the caller to prefetch off-lock and
@@ -672,7 +720,7 @@ impl ProcessManager {
             "starting managed process via {prov_name} provider (non-blocking)",
         );
 
-        self.fire_hook(HookEvent::AppStart, app_id, name, root, kind);
+        self.fire_hook(HookEvent::AppStart, app_id, name, root, kind, &app_row);
 
         cleanup_listen_target(&spec.listen_target);
 
@@ -759,32 +807,53 @@ impl ProcessManager {
                 name: name.to_string(),
                 root: root.to_path_buf(),
                 idle_timeout: app_idle_timeout,
+                app_snapshot: app_row,
             },
         );
 
         Ok(EnsureStarted::Status(StartStatus::Starting))
     }
 
-    /// Kill a specific managed process. Returns true if it was found and killed.
+    /// Kill a specific managed process, firing `AppStop` from the group's
+    /// spawn-time snapshot — complete route context and per-app hooks even
+    /// when the row is already deleted (orphan reap after prune or an
+    /// out-of-process scan). Returns true if it was found and killed.
     pub async fn kill_process(&mut self, app_id: i64) -> bool {
-        if let Some(group) = self.processes.remove(&app_id) {
-            info!(app_id, "killing managed process");
-            for companion in group.companions {
-                kill_handle(companion.handle).await;
+        match self.kill_process_quiet(app_id).await {
+            Some(stopped) => {
+                self.fire_hook(
+                    HookEvent::AppStop,
+                    app_id,
+                    &stopped.name,
+                    &stopped.root,
+                    &stopped.kind,
+                    &stopped.app_snapshot,
+                );
+                true
             }
-            kill_handle(group.primary.handle).await;
-            cleanup_listen_target(&group.primary.listen_target);
-            self.fire_hook(
-                HookEvent::AppStop,
-                app_id,
-                &group.name,
-                &group.root,
-                &group.primary.kind,
-            );
-            true
-        } else {
-            false
+            None => false,
         }
+    }
+
+    /// Kill without emitting `AppStop`; returns the stopped group's identity
+    /// and spawn-time snapshot. Deletion uses this and fires its own ordered
+    /// lifecycle events (`AppStop` then `AppRemove`) built from the deleted
+    /// row, which still carries the route/tunnel fields a post-delete store
+    /// lookup would miss.
+    pub async fn kill_process_quiet(&mut self, app_id: i64) -> Option<StoppedGroup> {
+        let group = self.processes.remove(&app_id)?;
+        info!(app_id, "killing managed process");
+        for companion in group.companions {
+            kill_handle(companion.handle).await;
+        }
+        kill_handle(group.primary.handle).await;
+        cleanup_listen_target(&group.primary.listen_target);
+        Some(StoppedGroup {
+            name: group.name,
+            root: group.root,
+            kind: group.primary.kind,
+            app_snapshot: group.app_snapshot,
+        })
     }
 
     pub fn mark_active(&mut self, app_id: i64) {
@@ -813,28 +882,43 @@ impl ProcessManager {
                     listen = %listen_target_display(&group.primary.listen_target),
                     "reaping idle managed process"
                 );
-                // Fire AppIdle before reaping
+                // Both contexts and the hook config derive from the group's
+                // spawn-time snapshot — one owned source, so the ordered
+                // AppIdle/AppStop pair can neither mix generations nor lose
+                // its hooks to a concurrent prune/rewrite (the events belong
+                // to the group, not to the row's continued existence). Both
+                // events then fire in one detached ordered task: AppIdle
+                // strictly before AppStop, and nothing is ever awaited under
+                // the PM lock — an app_idle webhook must not stall every
+                // start / delete for the HTTP timeout.
+                let snapshot = &group.app_snapshot;
                 let idle_ctx = self.hook_factory.context_for_process(
                     HookEvent::AppIdle,
                     *app_id,
                     &group.name,
                     &group.root,
                     &group.primary.kind,
+                    Some(snapshot),
                 );
-                self.hook_manager.fire(&idle_ctx).await;
-                for companion in group.companions {
-                    kill_handle(companion.handle).await;
-                }
-                kill_handle(group.primary.handle).await;
-                cleanup_listen_target(&group.primary.listen_target);
-                // Fire AppStop after kill
-                self.fire_hook(
+                let stop_ctx = self.hook_factory.context_for_process(
                     HookEvent::AppStop,
                     *app_id,
                     &group.name,
                     &group.root,
                     &group.primary.kind,
+                    Some(snapshot),
                 );
+                let app_hooks = snapshot.hooks.clone();
+                for companion in group.companions {
+                    kill_handle(companion.handle).await;
+                }
+                kill_handle(group.primary.handle).await;
+                cleanup_listen_target(&group.primary.listen_target);
+                let hm = self.hook_manager.clone();
+                tokio::spawn(async move {
+                    hm.fire_with_hooks(&idle_ctx, app_hooks.as_ref()).await;
+                    hm.fire_with_hooks(&stop_ctx, app_hooks.as_ref()).await;
+                });
             }
         }
 
@@ -845,19 +929,93 @@ impl ProcessManager {
     /// be deleted without the ProcessManager hearing about it — scanner prune
     /// after the app directory vanished, or an out-of-process `coulson scan`
     /// writing the shared DB — so the reaper reconciles against the store as
-    /// the single source of truth. Returns the number of groups killed.
-    pub async fn kill_orphans(&mut self, live_app_ids: &std::collections::HashSet<i64>) -> usize {
+    /// the single source of truth.
+    ///
+    /// `live_apps` maps app_id → (name, root, kind) of the store's current
+    /// managed apps. Ids are AUTOINCREMENT and never reused; the additional
+    /// identity match is defense-in-depth against in-place row rewrites (the
+    /// scanner can change a row's root/kind under the same id). Returns the
+    /// number of groups killed.
+    pub async fn kill_orphans(
+        &mut self,
+        live_apps: &HashMap<i64, (String, PathBuf, String)>,
+    ) -> usize {
         let orphans: Vec<i64> = self
             .processes
-            .keys()
-            .filter(|id| !live_app_ids.contains(id))
-            .copied()
+            .iter()
+            .filter(|(id, group)| {
+                live_apps.get(id).is_none_or(|(name, root, kind)| {
+                    !group_identity_matches(group, name, root, kind)
+                })
+            })
+            .map(|(id, _)| *id)
             .collect();
         for app_id in &orphans {
             info!(app_id, "reaping orphaned managed process (app removed)");
             self.kill_process(*app_id).await;
         }
         orphans.len()
+    }
+
+    /// If the group tracked under `app_id` disagrees with the caller's
+    /// identity (the scanner can rewrite a row's kind/root in place), the
+    /// store arbitrates: when the *caller* is the stale side — a request that
+    /// captured an old route — it is refused without touching the group; only
+    /// when the caller matches the current row is the mismatched group killed
+    /// so the app starts fresh.
+    async fn remove_stale_group(
+        &mut self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+    ) -> anyhow::Result<()> {
+        let conflicting = self
+            .processes
+            .get(&app_id)
+            .is_some_and(|g| !group_identity_matches(g, name, root, kind));
+        if conflicting {
+            let _current = self.validate_app_current(app_id, name, root, kind)?;
+            info!(
+                app_id,
+                "tracked process belongs to a superseded app; killing stale group"
+            );
+            self.kill_process(app_id).await;
+        }
+        Ok(())
+    }
+
+    /// Bail unless the store still has this managed app with the same
+    /// identity. A request that captured a route before deletion could
+    /// otherwise resurrect the app's process right after `app_delete()`
+    /// killed it. Runs under the PM lock at the point of committing to a
+    /// spawn, so it cannot interleave with deletion's row-delete + kill.
+    fn validate_app_current(
+        &self,
+        app_id: i64,
+        name: &str,
+        root: &Path,
+        kind: &str,
+    ) -> anyhow::Result<crate::domain::AppSpec> {
+        let row = self
+            .store
+            .get_by_id(app_id)
+            .context("store lookup before spawn")?;
+        let current = row.filter(|app| match &app.target {
+            crate::domain::BackendTarget::Managed {
+                root: r,
+                kind: k,
+                name: n,
+                ..
+            } => n == name && Path::new(r) == root && k == kind,
+            _ => false,
+        });
+        match current {
+            Some(app) => Ok(app),
+            None => {
+                anyhow::bail!("app {name} (id={app_id}) was removed or changed; refusing to start")
+            }
+        }
     }
 
     /// Kill all managed processes (called on daemon shutdown).
@@ -3280,6 +3438,70 @@ OVERRIDE = "toml_wins"
         .unwrap();
         let result = prefetch_env_url(&dir).await;
         assert!(result.is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // -- validate_app_current (pre-spawn store revalidation) --
+
+    #[test]
+    fn validate_app_current_gates_spawn_on_store_row() {
+        let dir =
+            std::env::temp_dir().join(format!("coulson-test-validate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(
+            crate::store::AppRepository::new(&dir.join("db.sqlite"), "coulson.local").unwrap(),
+        );
+        store.init_schema().unwrap();
+        let (log_tx, _rx) = broadcast::channel(8);
+        let pm = ProcessManager::new(ProcessManagerConfig {
+            idle_timeout: Duration::from_secs(60),
+            registry: Arc::new(default_registry()),
+            runtime_dir: dir.clone(),
+            backend: ProcessBackend::Direct,
+            hook_manager: Arc::new(crate::hooks::HookManager::new(dir.join("hooks"), 5)),
+            hook_factory: crate::hooks::HookContextFactory::new(
+                80,
+                None,
+                true,
+                false,
+                "coulson.local".to_string(),
+            ),
+            log_tx,
+            store: Arc::clone(&store),
+        });
+
+        let root = dir.join("myapp");
+        // No row → a deleted app must not be resurrected.
+        assert!(pm
+            .validate_app_current(1, "myapp", &root, "procfile")
+            .is_err());
+
+        let domain = crate::domain::DomainName("myapp.coulson.local".to_string());
+        let (app, _) = store
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                root.to_str().unwrap(),
+                "procfile",
+                true,
+                "fs",
+                "e",
+                None,
+            )
+            .unwrap();
+        // Matching identity → allowed.
+        assert!(pm
+            .validate_app_current(app.id.0, "myapp", &root, "procfile")
+            .is_ok());
+        // Same id but changed provider kind → refuse.
+        assert!(pm
+            .validate_app_current(app.id.0, "myapp", &root, "node")
+            .is_err());
+        // Same id but different app identity (reused id) → refuse.
+        assert!(pm
+            .validate_app_current(app.id.0, "other", &root, "procfile")
+            .is_err());
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/coulson/src/process/node.rs
+++ b/crates/coulson/src/process/node.rs
@@ -5,7 +5,8 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::provider::{
-    resolve_port, DetectedApp, ListenTarget, ManagedApp, ProcessProvider, ProcessSpec,
+    read_optional_detection_file, resolve_port, DetectedApp, ListenTarget, ManagedApp,
+    ProcessProvider, ProcessSpec,
 };
 
 /// Node.js provider — manages Node applications via `package.json` scripts.
@@ -23,41 +24,40 @@ impl ProcessProvider for NodeProvider {
         "Node.js"
     }
 
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp> {
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> anyhow::Result<Option<DetectedApp>> {
         if let Some(m) = manifest {
             if m.get("kind").and_then(|v| v.as_str()) == Some("node") {
-                return Some(DetectedApp {
+                return Ok(Some(DetectedApp {
                     kind: "node".into(),
                     meta: Value::Null,
-                });
+                }));
             }
         }
 
         // If a Procfile with a web process exists, defer to ProcfileProvider —
         // the developer explicitly defined a start command.
-        if has_procfile_web(dir) {
-            return None;
+        if has_procfile_web(dir)? {
+            return Ok(None);
         }
 
         // Convention: package.json with scripts.dev or scripts.start
         let pkg_path = dir.join("package.json");
-        if pkg_path.exists() {
-            if let Ok(raw) = std::fs::read_to_string(&pkg_path) {
-                if let Ok(pkg) = serde_json::from_str::<Value>(&raw) {
-                    let scripts = pkg.get("scripts");
-                    if let Some(s) = scripts {
-                        if s.get("dev").is_some() || s.get("start").is_some() {
-                            return Some(DetectedApp {
-                                kind: "node".into(),
-                                meta: Value::Null,
-                            });
-                        }
-                    }
+        if let Some(raw) = read_optional_detection_file(&pkg_path)? {
+            let pkg = serde_json::from_str::<Value>(&raw).map_err(|err| {
+                anyhow::anyhow!("invalid provider marker {}: {err}", pkg_path.display())
+            })?;
+            let scripts = pkg.get("scripts");
+            if let Some(s) = scripts {
+                if s.get("dev").is_some() || s.get("start").is_some() {
+                    return Ok(Some(DetectedApp {
+                        kind: "node".into(),
+                        meta: Value::Null,
+                    }));
                 }
             }
         }
 
-        None
+        Ok(None)
     }
 
     fn resolve(&self, app: &ManagedApp) -> anyhow::Result<ProcessSpec> {
@@ -229,18 +229,18 @@ fn detect_main_entry(root: &Path, pkg: &Value) -> anyhow::Result<String> {
 }
 
 /// Check if a Procfile.dev or Procfile with a `web:` process exists.
-fn has_procfile_web(dir: &Path) -> bool {
-    let content = if let Ok(c) = std::fs::read_to_string(dir.join("Procfile.dev")) {
-        c
-    } else if let Ok(c) = std::fs::read_to_string(dir.join("Procfile")) {
-        c
+fn has_procfile_web(dir: &Path) -> anyhow::Result<bool> {
+    let content = if let Some(content) = read_optional_detection_file(&dir.join("Procfile.dev"))? {
+        content
+    } else if let Some(content) = read_optional_detection_file(&dir.join("Procfile"))? {
+        content
     } else {
-        return false;
+        return Ok(false);
     };
-    content.lines().any(|l| {
+    Ok(content.lines().any(|l| {
         let trimmed = l.trim();
         trimmed.starts_with("web:") || trimmed.starts_with("web :")
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -266,7 +266,7 @@ mod tests {
         )
         .unwrap();
         let p = NodeProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -279,7 +279,7 @@ mod tests {
         )
         .unwrap();
         let p = NodeProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -288,7 +288,7 @@ mod tests {
         let dir = temp_dir("detect-noscripts");
         fs::write(dir.join("package.json"), r#"{"name":"foo"}"#).unwrap();
         let p = NodeProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).unwrap().is_none());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -296,7 +296,7 @@ mod tests {
     fn detect_node_no_match() {
         let dir = temp_dir("detect-nomatch");
         let p = NodeProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).unwrap().is_none());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -391,7 +391,10 @@ mod tests {
         .unwrap();
         fs::write(dir.join("Procfile"), "web: bin/rails s -p $PORT").unwrap();
         let p = NodeProvider;
-        assert!(p.detect(&dir, None).is_none(), "should defer to Procfile");
+        assert!(
+            p.detect(&dir, None).unwrap().is_none(),
+            "should defer to Procfile"
+        );
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -406,7 +409,7 @@ mod tests {
         fs::write(dir.join("Procfile"), "worker: sidekiq").unwrap();
         let p = NodeProvider;
         assert!(
-            p.detect(&dir, None).is_some(),
+            p.detect(&dir, None).unwrap().is_some(),
             "no web: in Procfile, should still detect Node"
         );
         fs::remove_dir_all(&dir).ok();
@@ -424,7 +427,7 @@ mod tests {
         let manifest = serde_json::json!({ "kind": "node" });
         let p = NodeProvider;
         assert!(
-            p.detect(&dir, Some(&manifest)).is_some(),
+            p.detect(&dir, Some(&manifest)).unwrap().is_some(),
             "kind=node should force Node provider"
         );
         fs::remove_dir_all(&dir).ok();

--- a/crates/coulson/src/process/procfile.rs
+++ b/crates/coulson/src/process/procfile.rs
@@ -5,7 +5,8 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::provider::{
-    resolve_port, DetectedApp, ListenTarget, ManagedApp, ProcessProvider, ProcessSpec,
+    read_optional_detection_file, resolve_port, DetectedApp, ListenTarget, ManagedApp,
+    ProcessProvider, ProcessSpec,
 };
 
 /// Spec for a companion process (no listen_target, no PORT).
@@ -33,28 +34,23 @@ const PROCFILE_DEV: &str = "Procfile.dev";
 const PROCFILE: &str = "Procfile";
 
 /// Read the Procfile content, preferring `Procfile.dev` over `Procfile`.
-fn read_procfile(dir: &Path) -> Option<String> {
+fn read_procfile(dir: &Path) -> anyhow::Result<Option<String>> {
     let dev = dir.join(PROCFILE_DEV);
-    if dev.exists() {
-        if let Ok(content) = std::fs::read_to_string(&dev) {
-            return Some(content);
-        }
+    if let Some(content) = read_optional_detection_file(&dev)? {
+        return Ok(Some(content));
     }
     let standard = dir.join(PROCFILE);
-    if standard.exists() {
-        if let Ok(content) = std::fs::read_to_string(&standard) {
-            return Some(content);
-        }
+    if let Some(content) = read_optional_detection_file(&standard)? {
+        return Ok(Some(content));
     }
-    None
+    Ok(None)
 }
 
 /// Check if parsed procfile content contains a `web` process type.
-fn has_web_process(content: &str) -> bool {
-    procfile::parse(content)
-        .ok()
-        .and_then(|procs| procs.get("web").map(|_| ()))
-        .is_some()
+fn has_web_process(content: &str) -> anyhow::Result<bool> {
+    let processes = procfile::parse(content)
+        .map_err(|err| anyhow::anyhow!("failed to parse Procfile: {err}"))?;
+    Ok(processes.contains_key("web"))
 }
 
 impl ProcfileProvider {
@@ -66,7 +62,7 @@ impl ProcfileProvider {
         process_type: &str,
     ) -> anyhow::Result<CompanionSpec> {
         let root = &app.root;
-        let content = read_procfile(root)
+        let content = read_procfile(root)?
             .ok_or_else(|| anyhow::anyhow!("no Procfile found in {}", root.display()))?;
         let procs = procfile::parse(&content)
             .map_err(|e| anyhow::anyhow!("failed to parse Procfile: {e}"))?;
@@ -101,29 +97,31 @@ impl ProcessProvider for ProcfileProvider {
         "Procfile"
     }
 
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp> {
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> anyhow::Result<Option<DetectedApp>> {
         // 1. manifest kind: "procfile" → direct match
         if let Some(m) = manifest {
             if m.get("kind").and_then(|v| v.as_str()) == Some("procfile") {
-                return Some(DetectedApp {
+                return Ok(Some(DetectedApp {
                     kind: "procfile".into(),
                     meta: Value::Null,
-                });
+                }));
             }
         }
 
         // 2. Read Procfile.dev (preferred) or Procfile
-        let content = read_procfile(dir)?;
+        let Some(content) = read_procfile(dir)? else {
+            return Ok(None);
+        };
 
         // 3. Must have a "web" process type
-        if has_web_process(&content) {
+        if has_web_process(&content)? {
             debug!(dir = %dir.display(), "detected Procfile with web process");
-            Some(DetectedApp {
+            Ok(Some(DetectedApp {
                 kind: "procfile".into(),
                 meta: Value::Null,
-            })
+            }))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -150,7 +148,7 @@ impl ProcessProvider for ProcfileProvider {
         }
 
         // 2. Read Procfile.dev / Procfile
-        let content = read_procfile(root)
+        let content = read_procfile(root)?
             .ok_or_else(|| anyhow::anyhow!("no Procfile found in {}", root.display()))?;
 
         // 3. Parse and extract web process
@@ -217,7 +215,7 @@ mod tests {
         )
         .unwrap();
         let p = ProcfileProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -227,7 +225,7 @@ mod tests {
         fs::write(dir.join("Procfile"), "web: rails s").unwrap();
         fs::write(dir.join("Procfile.dev"), "web: bin/dev").unwrap();
         let p = ProcfileProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -236,7 +234,7 @@ mod tests {
         let dir = temp_dir("detect-no-web");
         fs::write(dir.join("Procfile"), "worker: bundle exec sidekiq").unwrap();
         let p = ProcfileProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).unwrap().is_none());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -244,7 +242,7 @@ mod tests {
     fn detect_no_procfile() {
         let dir = temp_dir("detect-none");
         let p = ProcfileProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).unwrap().is_none());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -253,7 +251,7 @@ mod tests {
         let dir = temp_dir("detect-manifest");
         let manifest = serde_json::json!({ "kind": "procfile" });
         let p = ProcfileProvider;
-        assert!(p.detect(&dir, Some(&manifest)).is_some());
+        assert!(p.detect(&dir, Some(&manifest)).unwrap().is_some());
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/coulson/src/process/provider.rs
+++ b/crates/coulson/src/process/provider.rs
@@ -81,8 +81,10 @@ pub trait ProcessProvider: Send + Sync {
     /// Try to detect if `dir` contains an app this provider can manage.
     ///
     /// `manifest` is the parsed `.coulson.toml` content (as JSON Value) if present.
-    /// Returns `None` if the provider cannot handle this directory.
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp>;
+    /// Returns `Ok(None)` only for a definitive non-match. Filesystem and parse
+    /// uncertainty must be returned as `Err` so scanners do not turn a
+    /// half-written provider file into route removal or fallback reclassification.
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Result<Option<DetectedApp>>;
 
     /// Resolve a concrete [`ProcessSpec`] from the app context.
     fn resolve(&self, app: &ManagedApp) -> Result<ProcessSpec>;
@@ -127,13 +129,13 @@ impl ProviderRegistry {
         &self,
         dir: &Path,
         manifest: Option<&Value>,
-    ) -> Option<(&dyn ProcessProvider, DetectedApp)> {
+    ) -> Result<Option<(&dyn ProcessProvider, DetectedApp)>> {
         // If manifest explicitly specifies a kind, prefer that provider.
         if let Some(m) = manifest {
             if let Some(kind) = m.get("kind").and_then(|v| v.as_str()) {
                 if let Some(provider) = self.get(kind) {
-                    if let Some(detected) = provider.detect(dir, manifest) {
-                        return Some((provider, detected));
+                    if let Some(detected) = provider.detect(dir, manifest)? {
+                        return Ok(Some((provider, detected)));
                     }
                 }
             }
@@ -141,16 +143,39 @@ impl ProviderRegistry {
 
         // Otherwise, try each provider in priority order.
         for p in &self.providers {
-            if let Some(detected) = p.detect(dir, manifest) {
-                return Some((p.as_ref(), detected));
+            if let Some(detected) = p.detect(dir, manifest)? {
+                return Ok(Some((p.as_ref(), detected)));
             }
         }
-        None
+        Ok(None)
     }
 
     /// List all registered provider kind identifiers.
     pub fn kinds(&self) -> Vec<&str> {
         self.providers.iter().map(|p| p.kind()).collect()
+    }
+}
+
+/// Probe a provider marker without collapsing permission/I/O errors into
+/// absence. `Path::exists()` is unsuitable for discovery because it returns
+/// false for every metadata error.
+pub(crate) fn detection_path_exists(path: &Path) -> Result<bool> {
+    match std::fs::metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(anyhow::Error::new(err)
+            .context(format!("failed to stat provider marker {}", path.display()))),
+    }
+}
+
+/// Read an optional provider marker while preserving the distinction between
+/// NotFound (a definitive non-match) and unreadable/half-written content.
+pub(crate) fn read_optional_detection_file(path: &Path) -> Result<Option<String>> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(anyhow::Error::new(err)
+            .context(format!("failed to read provider marker {}", path.display()))),
     }
 }
 
@@ -297,14 +322,14 @@ mod tests {
         fn display_name(&self) -> &str {
             self.id
         }
-        fn detect(&self, _dir: &Path, _manifest: Option<&Value>) -> Option<DetectedApp> {
+        fn detect(&self, _dir: &Path, _manifest: Option<&Value>) -> Result<Option<DetectedApp>> {
             if self.should_detect {
-                Some(DetectedApp {
+                Ok(Some(DetectedApp {
                     kind: self.id.to_string(),
                     meta: Value::Null,
-                })
+                }))
             } else {
-                None
+                Ok(None)
             }
         }
         fn resolve(&self, _app: &ManagedApp) -> Result<ProcessSpec> {
@@ -345,7 +370,10 @@ mod tests {
         });
 
         let dir = Path::new("/tmp/fake");
-        let (provider, detected) = reg.detect(dir, None).expect("should detect");
+        let (provider, detected) = reg
+            .detect(dir, None)
+            .expect("detection succeeds")
+            .expect("should detect");
         assert_eq!(provider.kind(), "second"); // first matching wins
         assert_eq!(detected.kind, "second");
     }
@@ -364,7 +392,10 @@ mod tests {
 
         let dir = Path::new("/tmp/fake");
         let manifest = serde_json::json!({ "kind": "second" });
-        let (provider, _) = reg.detect(dir, Some(&manifest)).expect("should detect");
+        let (provider, _) = reg
+            .detect(dir, Some(&manifest))
+            .expect("detection succeeds")
+            .expect("should detect");
         assert_eq!(provider.kind(), "second"); // manifest kind wins
     }
 

--- a/crates/coulson/src/process/rack.rs
+++ b/crates/coulson/src/process/rack.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use super::provider::{DetectedApp, ManagedApp, ProcessProvider, ProcessSpec};
+use super::provider::{
+    detection_path_exists, DetectedApp, ManagedApp, ProcessProvider, ProcessSpec,
+};
 
 /// Rack/Puma provider — manages Ruby Rack applications.
 ///
@@ -20,25 +22,25 @@ impl ProcessProvider for RackProvider {
         "Ruby Rack"
     }
 
-    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> Option<DetectedApp> {
+    fn detect(&self, dir: &Path, manifest: Option<&Value>) -> anyhow::Result<Option<DetectedApp>> {
         if let Some(m) = manifest {
             if m.get("kind").and_then(|v| v.as_str()) == Some("rack") {
-                return Some(DetectedApp {
+                return Ok(Some(DetectedApp {
                     kind: "rack".into(),
                     meta: Value::Null,
-                });
+                }));
             }
         }
 
         // Convention: config.ru + Gemfile
-        if dir.join("config.ru").exists() {
-            return Some(DetectedApp {
+        if detection_path_exists(&dir.join("config.ru"))? {
+            return Ok(Some(DetectedApp {
                 kind: "rack".into(),
                 meta: Value::Null,
-            });
+            }));
         }
 
-        None
+        Ok(None)
     }
 
     fn resolve(&self, _app: &ManagedApp) -> anyhow::Result<ProcessSpec> {
@@ -65,7 +67,7 @@ mod tests {
         let dir = temp_dir("detect-configru");
         fs::write(dir.join("config.ru"), "run MyApp").unwrap();
         let p = RackProvider;
-        assert!(p.detect(&dir, None).is_some());
+        assert!(p.detect(&dir, None).expect("detection succeeds").is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -74,7 +76,10 @@ mod tests {
         let dir = temp_dir("detect-manifest");
         let p = RackProvider;
         let m = serde_json::json!({ "kind": "rack" });
-        assert!(p.detect(&dir, Some(&m)).is_some());
+        assert!(p
+            .detect(&dir, Some(&m))
+            .expect("detection succeeds")
+            .is_some());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -83,7 +88,7 @@ mod tests {
         let dir = temp_dir("detect-nomatch");
         fs::write(dir.join("index.html"), "").unwrap();
         let p = RackProvider;
-        assert!(p.detect(&dir, None).is_none());
+        assert!(p.detect(&dir, None).expect("detection succeeds").is_none());
         fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/coulson/src/scanner/mod.rs
+++ b/crates/coulson/src/scanner/mod.rs
@@ -598,8 +598,22 @@ fn discover(
                 continue;
             }
 
-            // Auto-detect managed app via provider registry
-            if let Some((_provider, detected)) = registry.detect(&entry.path(), None) {
+            // Auto-detect managed app via provider registry. A provider error
+            // is not a non-match: protect the existing row and do not fall
+            // through to `public/`, which could rewrite a managed app as
+            // static while its metadata is only half-written.
+            let detected = match registry.detect(&entry.path(), None) {
+                Ok(result) => result,
+                Err(err) => {
+                    indeterminate_entries.push(dir_name.clone());
+                    parse_warnings.push(format!(
+                        "{}: provider detection indeterminate ({err}); entry left untouched",
+                        entry.path().display()
+                    ));
+                    continue;
+                }
+            };
+            if let Some((_provider, detected)) = detected {
                 let domain_text = file_name_to_domain(&dir_name, suffix);
                 let domain = DomainName::parse(&domain_text, suffix).with_context(|| {
                     format!(
@@ -660,14 +674,6 @@ fn discover(
                     hooks: None,
                 };
                 insert_with_priority(&mut by_route, &mut conflicts, app);
-            } else {
-                // The entry exists but nothing classified it. Provider
-                // detection swallows read/parse errors internally (e.g. a
-                // truncated package.json mid-rewrite), so a non-match is NOT
-                // proof the app is gone — only entry removal is. Protect the
-                // entry's rows from this scan's prune; junk directories have
-                // no rows, so protection is a no-op for them.
-                indeterminate_entries.push(dir_name.clone());
             }
         }
     }
@@ -850,8 +856,20 @@ fn discover_from_symlink(
             return Ok(out);
         }
 
-        // Auto-detect managed app via provider registry
-        if let Some((_prov, detected)) = registry.detect(&resolved_target, None) {
+        // Auto-detect managed app via provider registry. Preserve the same
+        // Match / NoMatch / Indeterminate distinction as direct directories.
+        let detected = match registry.detect(&resolved_target, None) {
+            Ok(result) => result,
+            Err(err) => {
+                indeterminate_entries.push(file_name.to_string());
+                outer_parse_warnings.push(format!(
+                    "{}: provider detection indeterminate ({err}); entry left untouched",
+                    resolved_target.display()
+                ));
+                return Ok(Vec::new());
+            }
+        };
+        if let Some((_prov, detected)) = detected {
             let root_str = resolved_target.to_string_lossy().to_string();
             let app_kind = kind_str_to_app_kind(&detected.kind);
             return Ok(vec![DiscoveredStaticApp {
@@ -898,10 +916,6 @@ fn discover_from_symlink(
         }
     }
 
-    // Symlink target exists but nothing classified it (provider detection
-    // swallows its own errors) — same contract as the directory branch:
-    // a non-match must not read as absence, so protect the entry's rows.
-    indeterminate_entries.push(file_name.to_string());
     Ok(Vec::new())
 }
 
@@ -933,7 +947,9 @@ fn manifest_to_discovered_apps(
 
     // Build a serde_json::Value from manifest for provider detection
     let manifest_value = manifest_to_json_value(manifest);
-    let is_managed = registry.detect(dir_path, Some(&manifest_value));
+    let is_managed = registry
+        .detect(dir_path, Some(&manifest_value))
+        .with_context(|| format!("provider detection failed in {}", dir_path.display()))?;
 
     if let Some((_prov, detected)) = is_managed {
         let root_str = dir_path.to_string_lossy().to_string();
@@ -1414,16 +1430,23 @@ mod tests {
         std::fs::write(base.join("okapp"), "5006\n").expect("write ok");
 
         // A directory whose provider metadata is momentarily unusable (e.g.
-        // package.json truncated mid-rewrite): detection finds nothing, but
-        // that is a classification failure, not absence.
+        // package.json truncated mid-rewrite). `public/` is deliberately
+        // present: detection uncertainty must not fall through and rewrite
+        // the managed route as static.
         std::fs::create_dir_all(base.join("nodeapp")).expect("mkdir nodeapp");
         std::fs::write(base.join("nodeapp/package.json"), "{ trunca").expect("write trunc");
+        std::fs::create_dir_all(base.join("nodeapp/public")).expect("mkdir public");
+
+        // A definitive non-match must remain removable. This models a retired
+        // app whose last provider/static marker was intentionally deleted
+        // while its now-empty directory still exists.
+        std::fs::create_dir_all(base.join("retired")).expect("mkdir retired");
 
         let registry = crate::process::default_registry();
         let result = discover(&base, "coulson.local", &registry, &[]).expect("discover");
-        // Unreadable / unclassifiable entries are neither routes nor absent:
-        // they land in the indeterminate set (protecting their rows from
-        // prune), while the healthy entry is discovered normally.
+        // Only actual detection errors enter the indeterminate set. The
+        // definite non-match is omitted, allowing an old row it owned to be
+        // pruned, while the healthy entry is discovered normally.
         let mut indeterminate = result.indeterminate_entries.clone();
         indeterminate.sort();
         assert_eq!(
@@ -1433,6 +1456,50 @@ mod tests {
         assert_eq!(result.apps.len(), 1);
         assert_eq!(result.apps[0].fs_entry, "okapp");
         assert!(result.parse_warnings.iter().any(|w| w.contains("myapp")));
+        assert!(result
+            .parse_warnings
+            .iter()
+            .any(|w| w.contains("nodeapp") && w.contains("provider detection indeterminate")));
+
+        // End-to-end prune distinction: the invalid Node entry survives even
+        // with public/ present, while the definitive non-match is removed.
+        let repo = crate::store::AppRepository::new(&base.join("state.sqlite"), "coulson.local")
+            .expect("open store");
+        repo.init_schema().expect("schema");
+        let node_domain = DomainName("nodeapp.coulson.local".to_string());
+        let retired_domain = DomainName("retired.coulson.local".to_string());
+        let (node_row, _) = repo
+            .upsert_scanned_managed(
+                "nodeapp",
+                &node_domain,
+                base.join("nodeapp").to_str().unwrap(),
+                "node",
+                true,
+                "apps_root",
+                "nodeapp",
+                None,
+            )
+            .expect("seed node row");
+        let (retired_row, _) = repo
+            .upsert_scanned_managed(
+                "retired",
+                &retired_domain,
+                base.join("retired").to_str().unwrap(),
+                "node",
+                true,
+                "apps_root",
+                "retired",
+                None,
+            )
+            .expect("seed retired row");
+        let protected: HashSet<String> = result.indeterminate_entries.into_iter().collect();
+        let pruned = repo
+            .prune_scanned_not_in("apps_root", &HashSet::new(), &protected)
+            .expect("prune");
+        assert!(repo.get_by_id(node_row.id.0).unwrap().is_some());
+        assert!(repo.get_by_id(retired_row.id.0).unwrap().is_none());
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0].id, retired_row.id);
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/crates/coulson/src/scanner/mod.rs
+++ b/crates/coulson/src/scanner/mod.rs
@@ -185,9 +185,16 @@ pub struct ScanResult {
     pub stats: ScanStats,
     /// Apps newly inserted during this scan (for firing `app_add` hooks after route reload).
     pub added_apps: Vec<AppSpec>,
+    /// Rows removed because their route disappeared. The daemon tears down
+    /// their processes and fires `app_stop` from these snapshots — after the
+    /// prune the row is gone, and each snapshot carries its own hook config.
+    pub pruned_apps: Vec<AppSpec>,
 }
 
 pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
+    // One scan at a time: discovery and the write transaction below form a
+    // unit that must not interleave with a concurrent (manual vs watcher) scan.
+    let _scan_guard = state.scan_mutex.lock();
     let skip_paths: Vec<&Path> = vec![
         state.scan_warnings_path.as_path(),
         state.sqlite_path.as_path(),
@@ -203,13 +210,29 @@ pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
     let mut updated = 0usize;
     let mut skipped_manual = 0usize;
     let mut added_apps: Vec<AppSpec> = Vec::new();
-    // Clear all per-app hooks before re-registering from scan results.
-    state.hook_manager.clear_all_app_hooks();
+    // All store mutations of this scan commit as ONE write transaction: a
+    // partially applied scan would otherwise leave rewritten rows in the
+    // store while routes and hooks still describe the pre-scan state — and
+    // the identity-aware reaper would kill the still-running old groups.
+    let txn = state.store.begin_write()?;
     for app in &discovered.apps {
+        // discover() read the filesystem before this transaction, and an app
+        // can have been explicitly deleted since (row + fs entry are removed
+        // under their own write transaction). Inside our transaction nothing
+        // else can be mutating that pair, so a definitively missing entry is
+        // authoritative: skip the stale discovery instead of resurrecting
+        // the app, and leave its route out of `active_routes` so the prune
+        // below drops any leftover row. Only NotFound means absent — any
+        // other stat error fails the scan (`?`) and rolls the whole
+        // transaction back, because pruning a live-but-unreadable app would
+        // tear down its process over a transient fs error.
+        if entry_definitively_absent(&state.apps_root, &app.fs_entry)? {
+            continue;
+        }
         let (spec, op) = match app.target_type.as_str() {
             "managed" => {
                 let kind_str = app_kind_to_str(app.kind);
-                state.store.upsert_scanned_managed(
+                txn.upsert_scanned_managed(
                     &app.name,
                     &app.domain,
                     &app.target_value,
@@ -217,17 +240,19 @@ pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
                     app.enabled,
                     "apps_root",
                     &app.fs_entry,
+                    app.hooks.as_ref(),
                 )?
             }
-            "static_dir" => state.store.upsert_scanned_static_dir(
+            "static_dir" => txn.upsert_scanned_static_dir(
                 &app.name,
                 &app.domain,
                 &app.target_value,
                 app.enabled,
                 "apps_root",
                 &app.fs_entry,
+                app.hooks.as_ref(),
             )?,
-            _ => state.store.upsert_scanned_static(
+            _ => txn.upsert_scanned_static(
                 &StaticAppInput {
                     name: &app.name,
                     domain: &app.domain,
@@ -245,36 +270,32 @@ pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
                 app.enabled,
                 "apps_root",
                 &app.fs_entry,
+                app.hooks.as_ref(),
             )?,
         };
         match op {
             ScanUpsertResult::Inserted => {
                 inserted += 1;
-                // Register per-app hooks only for scan-owned apps
-                if let Some(ref hooks_config) = app.hooks {
-                    state
-                        .hook_manager
-                        .register_app_hooks(spec.id.0, hooks_config.clone());
-                }
                 added_apps.push(spec);
             }
-            ScanUpsertResult::Updated => {
-                updated += 1;
-                if let Some(ref hooks_config) = app.hooks {
-                    state
-                        .hook_manager
-                        .register_app_hooks(spec.id.0, hooks_config.clone());
-                }
-            }
+            ScanUpsertResult::Updated => updated += 1,
             ScanUpsertResult::SkippedManual => skipped_manual += 1,
         }
         let domain_prefix = domain_to_db(&app.domain.0, &state.domain_suffix);
         let route_key = route_key(&domain_prefix, app.path_prefix.as_deref().unwrap_or(""));
         active_routes.insert(route_key);
     }
-    let pruned = state
-        .store
-        .prune_scanned_not_in("apps_root", &active_routes)?;
+    // Rows owned by indeterminate entries (content unreadable right now) are
+    // protected: they are not in `active_routes`, but their absence is not
+    // established either, so pruning them would destroy a live app over a
+    // transient condition.
+    let protected_fs_entries: HashSet<String> =
+        discovered.indeterminate_entries.iter().cloned().collect();
+    let pruned_apps =
+        txn.prune_scanned_not_in("apps_root", &active_routes, &protected_fs_entries)?;
+    // The commit is also the hook-config commit: hooks live on the rows, so
+    // there is no separate registry swap that could race a deletion.
+    txn.commit()?;
     let conflict_domains: Vec<String> = discovered
         .conflicts
         .into_iter()
@@ -288,7 +309,7 @@ pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
             inserted,
             updated,
             skipped_manual,
-            pruned,
+            pruned: pruned_apps.len(),
             conflicts: conflict_domains.len(),
             conflict_domains,
             parse_warnings,
@@ -296,7 +317,49 @@ pub fn sync_from_apps_root(state: &SharedState) -> anyhow::Result<ScanResult> {
             has_issues: warning_count > 0,
         },
         added_apps,
+        pruned_apps,
     })
+}
+
+/// Whether an apps_root entry is definitively absent. Only `NotFound` means
+/// absent; any other stat error is propagated so callers treating absence as
+/// "app was deleted" (scan revalidation → prune) fail instead of destroying
+/// state over a transient permission/I/O error.
+fn entry_definitively_absent(apps_root: &Path, fs_entry: &str) -> anyhow::Result<bool> {
+    let path = apps_root.join(fs_entry);
+    match fs::symlink_metadata(&path) {
+        Ok(_) => Ok(false),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(anyhow::Error::new(err).context(format!(
+            "failed to stat apps_root entry: {}",
+            path.display()
+        ))),
+    }
+}
+
+/// Whether a path definitively exists. `Ok(false)` only on `NotFound`; any
+/// other stat error propagates — absence inferred from an error must never
+/// drive discovery fallthrough (and thereby prune).
+fn path_definitively_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => {
+            Err(anyhow::Error::new(err).context(format!("failed to stat: {}", path.display())))
+        }
+    }
+}
+
+/// Whether a directory definitively exists at `path` (`NotFound` → false;
+/// other stat errors propagate, same contract as [`path_definitively_exists`]).
+fn dir_definitively_exists(path: &Path) -> anyhow::Result<bool> {
+    match fs::metadata(path) {
+        Ok(m) => Ok(m.is_dir()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => {
+            Err(anyhow::Error::new(err).context(format!("failed to stat: {}", path.display())))
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -324,6 +387,10 @@ struct DiscoverResult {
     apps: Vec<DiscoveredStaticApp>,
     conflicts: Vec<String>,
     parse_warnings: Vec<String>,
+    /// apps_root entries whose content could not be interpreted right now
+    /// (e.g. invalid UTF-8 mid-rewrite). Not routes, but not absence either:
+    /// rows owned by these entries are protected from this scan's prune.
+    indeterminate_entries: Vec<String>,
 }
 
 fn discover(
@@ -332,17 +399,29 @@ fn discover(
     registry: &ProviderRegistry,
     skip_paths: &[&Path],
 ) -> anyhow::Result<DiscoverResult> {
-    if !root.exists() {
-        return Ok(DiscoverResult {
-            apps: Vec::new(),
-            conflicts: Vec::new(),
-            parse_warnings: Vec::new(),
-        });
+    // `Path::exists()` swallows stat errors as `false`; an unreadable apps
+    // root would then read as an empty discovery and prune every scan-owned
+    // row. Only a definitive NotFound may mean "no apps root".
+    match fs::metadata(root) {
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(DiscoverResult {
+                apps: Vec::new(),
+                conflicts: Vec::new(),
+                parse_warnings: Vec::new(),
+                indeterminate_entries: Vec::new(),
+            });
+        }
+        Err(err) => {
+            return Err(anyhow::Error::new(err)
+                .context(format!("failed to stat apps root: {}", root.display())))
+        }
     }
 
     let mut by_route: HashMap<String, DiscoveredStaticApp> = HashMap::new();
     let mut conflicts: Vec<String> = Vec::new();
     let mut parse_warnings: Vec<String> = Vec::new();
+    let mut indeterminate_entries: Vec<String> = Vec::new();
 
     for entry in fs::read_dir(root)
         .with_context(|| format!("failed reading apps root: {}", root.display()))?
@@ -361,7 +440,14 @@ fn discover(
             if file_name.starts_with('.') {
                 continue;
             }
-            let apps = discover_from_symlink(entry.path(), &file_name, suffix, registry)?;
+            let apps = discover_from_symlink(
+                entry.path(),
+                &file_name,
+                suffix,
+                registry,
+                &mut indeterminate_entries,
+                &mut parse_warnings,
+            )?;
             for app in apps {
                 insert_with_priority(&mut by_route, &mut conflicts, app);
             }
@@ -380,9 +466,25 @@ fn discover(
             }
             let raw = match fs::read_to_string(entry.path()) {
                 Ok(r) => r,
-                Err(_) => {
-                    // Skip files that can't be read as UTF-8 (binary files)
+                // NotFound = removed mid-scan → definitive non-route.
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                // InvalidData = binary or a half-rewritten UTF-8 file. Not a
+                // route right now, but not absence either — the entry may own
+                // live routes, so it goes into the indeterminate set and this
+                // scan will not prune its rows.
+                Err(err) if err.kind() == std::io::ErrorKind::InvalidData => {
+                    indeterminate_entries.push(file_name.clone());
+                    parse_warnings.push(format!(
+                        "{}: unreadable content ({err}); entry left untouched",
+                        entry.path().display()
+                    ));
                     continue;
+                }
+                // Anything else (permissions, I/O) fails the scan rather than
+                // silently dropping — and thereby pruning — a live route.
+                Err(err) => {
+                    return Err(anyhow::Error::new(err)
+                        .context(format!("failed to read {}", entry.path().display())))
                 }
             };
             let parse = parse_pow_file_routes(&raw);
@@ -432,7 +534,7 @@ fn discover(
 
             // Priority: .coulson.toml → .coulson → provider auto-detect → public/
             let toml_path = entry.path().join(".coulson.toml");
-            if toml_path.exists() {
+            if path_definitively_exists(&toml_path)? {
                 let raw = fs::read_to_string(&toml_path)
                     .with_context(|| format!("failed reading {}", toml_path.display()))?;
                 let manifest = parse_manifest(&raw)
@@ -452,7 +554,7 @@ fn discover(
             }
 
             let coulson_file = entry.path().join(".coulson");
-            if coulson_file.exists() {
+            if path_definitively_exists(&coulson_file)? {
                 let raw = fs::read_to_string(&coulson_file)
                     .with_context(|| format!("failed reading {}", coulson_file.display()))?;
                 let parse = parse_pow_file_routes(&raw);
@@ -528,7 +630,7 @@ fn discover(
                     hooks: None,
                 };
                 insert_with_priority(&mut by_route, &mut conflicts, app);
-            } else if entry.path().join("public").is_dir() {
+            } else if dir_definitively_exists(&entry.path().join("public"))? {
                 let domain_text = file_name_to_domain(&dir_name, suffix);
                 let domain = DomainName::parse(&domain_text, suffix).with_context(|| {
                     format!(
@@ -558,6 +660,14 @@ fn discover(
                     hooks: None,
                 };
                 insert_with_priority(&mut by_route, &mut conflicts, app);
+            } else {
+                // The entry exists but nothing classified it. Provider
+                // detection swallows read/parse errors internally (e.g. a
+                // truncated package.json mid-rewrite), so a non-match is NOT
+                // proof the app is gone — only entry removal is. Protect the
+                // entry's rows from this scan's prune; junk directories have
+                // no rows, so protection is a no-op for them.
+                indeterminate_entries.push(dir_name.clone());
             }
         }
     }
@@ -576,14 +686,18 @@ fn discover(
         apps,
         conflicts,
         parse_warnings,
+        indeterminate_entries,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn discover_from_symlink(
     link_path: PathBuf,
     file_name: &str,
     suffix: &str,
     registry: &ProviderRegistry,
+    indeterminate_entries: &mut Vec<String>,
+    outer_parse_warnings: &mut Vec<String>,
 ) -> anyhow::Result<Vec<DiscoveredStaticApp>> {
     let target = fs::read_link(&link_path)
         .with_context(|| format!("failed reading symlink {}", link_path.display()))?;
@@ -598,7 +712,16 @@ fn discover_from_symlink(
 
     let meta = match fs::metadata(&resolved_target) {
         Ok(m) => m,
-        Err(_) => return Ok(Vec::new()),
+        // A dangling symlink is a definitively absent app; any other stat
+        // error must fail the scan — treating it as absence would prune a
+        // live route over a transient fs error.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(anyhow::Error::new(err).context(format!(
+                "failed to stat symlink target: {}",
+                resolved_target.display()
+            )))
+        }
     };
 
     let domain_text = file_name_to_domain(file_name, suffix);
@@ -613,8 +736,22 @@ fn discover_from_symlink(
     let name = sanitize_name(file_name);
 
     if meta.is_file() {
-        let raw = fs::read_to_string(&resolved_target)
-            .with_context(|| format!("failed reading {}", resolved_target.display()))?;
+        let raw = match fs::read_to_string(&resolved_target) {
+            Ok(r) => r,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) if err.kind() == std::io::ErrorKind::InvalidData => {
+                indeterminate_entries.push(file_name.to_string());
+                outer_parse_warnings.push(format!(
+                    "{}: unreadable content ({err}); entry left untouched",
+                    resolved_target.display()
+                ));
+                return Ok(Vec::new());
+            }
+            Err(err) => {
+                return Err(anyhow::Error::new(err)
+                    .context(format!("failed reading {}", resolved_target.display())))
+            }
+        };
         let is_toml = resolved_target
             .extension()
             .map(|ext| ext == "toml")
@@ -664,7 +801,7 @@ fn discover_from_symlink(
     if meta.is_dir() {
         // Priority: .coulson.toml → .coulson → provider auto-detect → public/
         let coulson_toml_file = resolved_target.join(".coulson.toml");
-        if coulson_toml_file.exists() {
+        if path_definitively_exists(&coulson_toml_file)? {
             let raw = fs::read_to_string(&coulson_toml_file)
                 .with_context(|| format!("failed reading {}", coulson_toml_file.display()))?;
             let manifest = parse_manifest(&raw)
@@ -685,7 +822,7 @@ fn discover_from_symlink(
 
         // .coulson (powfile format) in the directory
         let coulson_file = resolved_target.join(".coulson");
-        if coulson_file.exists() {
+        if path_definitively_exists(&coulson_file)? {
             let raw = fs::read_to_string(&coulson_file)
                 .with_context(|| format!("failed reading {}", coulson_file.display()))?;
             let mut out = Vec::new();
@@ -737,7 +874,7 @@ fn discover_from_symlink(
                 hooks: None,
             }]);
         }
-        if resolved_target.join("public").is_dir() {
+        if dir_definitively_exists(&resolved_target.join("public"))? {
             let public_root = resolved_target.join("public").to_string_lossy().to_string();
             return Ok(vec![DiscoveredStaticApp {
                 name,
@@ -761,6 +898,10 @@ fn discover_from_symlink(
         }
     }
 
+    // Symlink target exists but nothing classified it (provider detection
+    // swallows its own errors) — same contract as the directory branch:
+    // a non-match must not read as absence, so protect the entry's rows.
+    indeterminate_entries.push(file_name.to_string());
     Ok(Vec::new())
 }
 
@@ -1088,55 +1229,87 @@ fn parse_target_token(token: &str) -> Option<(String, u16)> {
     Some((host.to_string(), port))
 }
 
+/// Outcome of [`remove_app_fs_entry`]. `Refused` matters to deletion: an
+/// entry that still exists after a committed delete is rediscovered by the
+/// next scan, so callers must treat it as an error, not a no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsEntryRemoval {
+    /// Entry existed and was removed.
+    Removed,
+    /// Nothing to remove — the entry is already gone.
+    Missing,
+    /// Entry exists but was not removed (directory, or removal failed).
+    Refused,
+}
+
 /// Remove the filesystem entry from apps_root.
 ///
-/// - symlink → remove symlink + clean up .coulson/.coulson.toml target file
+/// - symlink → remove symlink first, then best-effort cleanup of its
+///   .coulson/.coulson.toml target file
 /// - file → remove file
-/// - directory → skip (return false)
+/// - directory → refuse (never delete user data)
 ///
-/// Returns true if something was actually removed.
-pub fn remove_app_fs_entry(apps_root: &Path, fs_entry: &str) -> bool {
+/// A `Refused` result must leave everything untouched: callers abort the
+/// deletion on it, so the entry removal — the fallible, load-bearing step —
+/// happens before any irreversible side cleanup, never after.
+pub fn remove_app_fs_entry(apps_root: &Path, fs_entry: &str) -> FsEntryRemoval {
     let path = apps_root.join(fs_entry);
     let meta = match std::fs::symlink_metadata(&path) {
         Ok(m) => m,
-        Err(_) => return false,
+        // Only a definitive "not there" is Missing (safe to commit a delete
+        // over). Permission or transient I/O errors mean the entry may still
+        // exist and be rediscovered — refuse.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return FsEntryRemoval::Missing,
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "failed to stat fs entry");
+            return FsEntryRemoval::Refused;
+        }
     };
 
     if meta.file_type().is_dir() {
-        tracing::debug!(path = %path.display(), "skipping directory removal");
-        return false;
+        tracing::debug!(path = %path.display(), "refusing directory removal");
+        return FsEntryRemoval::Refused;
     }
 
-    // If it's a symlink pointing to a .coulson or .coulson.toml file, clean that up too
-    if meta.file_type().is_symlink() {
-        if let Ok(target) = std::fs::read_link(&path) {
-            let resolved = if target.is_absolute() {
-                target
-            } else {
-                apps_root.join(&target)
-            };
-            if resolved.is_file() {
-                if let Some(fname) = resolved.file_name().and_then(|n| n.to_str()) {
-                    if fname == ".coulson" || fname == ".coulson.toml" {
-                        if let Err(err) = std::fs::remove_file(&resolved) {
-                            tracing::warn!(path = %resolved.display(), error = %err, "failed to remove symlink target file");
-                        }
-                    }
+    // Snapshot the symlink's config-file target before removing the link —
+    // afterwards it can no longer be resolved.
+    let cleanup_target = if meta.file_type().is_symlink() {
+        std::fs::read_link(&path)
+            .ok()
+            .map(|target| {
+                if target.is_absolute() {
+                    target
+                } else {
+                    apps_root.join(&target)
                 }
-            }
-        }
-    }
+            })
+            .filter(|resolved| {
+                resolved.is_file()
+                    && resolved
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|f| f == ".coulson" || f == ".coulson.toml")
+            })
+    } else {
+        None
+    };
 
     match std::fs::remove_file(&path) {
-        Ok(()) => {
-            tracing::info!(path = %path.display(), "removed fs entry");
-            true
-        }
+        Ok(()) => tracing::info!(path = %path.display(), "removed fs entry"),
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to remove fs entry");
-            false
+            return FsEntryRemoval::Refused;
         }
     }
+
+    // Entry is gone — target cleanup is best effort and cannot affect the
+    // outcome anymore.
+    if let Some(resolved) = cleanup_target {
+        if let Err(err) = std::fs::remove_file(&resolved) {
+            tracing::warn!(path = %resolved.display(), error = %err, "failed to remove symlink target file");
+        }
+    }
+    FsEntryRemoval::Removed
 }
 
 pub(crate) fn sanitize_name(name: &str) -> String {
@@ -1229,6 +1402,114 @@ fn humanize_route_conflict_key(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalid_utf8_entry_is_indeterminate_not_absent() {
+        let base = std::env::temp_dir().join(format!("coulson-test-indet-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("mkdir");
+        // A pow-style route file that is temporarily invalid UTF-8 (e.g. a
+        // half-rewritten file observed by a watcher scan).
+        std::fs::write(base.join("myapp"), [0xff, 0xfe, 0x00, 0x80]).expect("write binary");
+        std::fs::write(base.join("okapp"), "5006\n").expect("write ok");
+
+        // A directory whose provider metadata is momentarily unusable (e.g.
+        // package.json truncated mid-rewrite): detection finds nothing, but
+        // that is a classification failure, not absence.
+        std::fs::create_dir_all(base.join("nodeapp")).expect("mkdir nodeapp");
+        std::fs::write(base.join("nodeapp/package.json"), "{ trunca").expect("write trunc");
+
+        let registry = crate::process::default_registry();
+        let result = discover(&base, "coulson.local", &registry, &[]).expect("discover");
+        // Unreadable / unclassifiable entries are neither routes nor absent:
+        // they land in the indeterminate set (protecting their rows from
+        // prune), while the healthy entry is discovered normally.
+        let mut indeterminate = result.indeterminate_entries.clone();
+        indeterminate.sort();
+        assert_eq!(
+            indeterminate,
+            vec!["myapp".to_string(), "nodeapp".to_string()]
+        );
+        assert_eq!(result.apps.len(), 1);
+        assert_eq!(result.apps[0].fs_entry, "okapp");
+        assert!(result.parse_warnings.iter().any(|w| w.contains("myapp")));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn entry_absence_only_definitive_for_not_found() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = std::env::temp_dir().join(format!("coulson-test-absent-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let apps_root = base.join("apps");
+        std::fs::create_dir_all(&apps_root).expect("mkdir");
+        std::fs::write(apps_root.join("present"), "5006\n").expect("write");
+
+        assert!(!entry_definitively_absent(&apps_root, "present").expect("stat present"));
+        assert!(entry_definitively_absent(&apps_root, "gone").expect("stat gone"));
+
+        // Untraversable parent: the entry may still exist — this must be an
+        // error (scan rollback), never "absent" (prune of a live app).
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod no-exec");
+        let result = entry_definitively_absent(&apps_root, "present");
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod rw");
+        assert!(result.is_err(), "stat error must not read as absence");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn refused_symlink_removal_preserves_target_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let base =
+            std::env::temp_dir().join(format!("coulson-test-fsentry-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let apps_root = base.join("apps");
+        let src = base.join("src");
+        std::fs::create_dir_all(&apps_root).expect("mkdir apps");
+        std::fs::create_dir_all(&src).expect("mkdir src");
+        let target = src.join(".coulson");
+        std::fs::write(&target, "5006\n").expect("write target");
+        std::os::unix::fs::symlink(&target, apps_root.join("myapp")).expect("symlink");
+
+        // Read-only apps_root: the symlink cannot be unlinked. The refusal
+        // must leave BOTH the symlink and its config-file target untouched.
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod ro");
+        let refused = remove_app_fs_entry(&apps_root, "myapp");
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod rw");
+        assert_eq!(refused, FsEntryRemoval::Refused);
+        assert!(
+            target.exists(),
+            "refused removal must not delete the target"
+        );
+        assert!(apps_root.join("myapp").symlink_metadata().is_ok());
+
+        // Unstattable entry (parent not traversable) is Refused, not Missing:
+        // it may still exist and be rediscovered by a scan.
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod no-exec");
+        let unstattable = remove_app_fs_entry(&apps_root, "myapp");
+        std::fs::set_permissions(&apps_root, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod rw");
+        assert_eq!(unstattable, FsEntryRemoval::Refused);
+
+        // Writable root: removal succeeds and then cleans the target too.
+        assert_eq!(
+            remove_app_fs_entry(&apps_root, "myapp"),
+            FsEntryRemoval::Removed
+        );
+        assert!(!target.exists());
+        assert_eq!(
+            remove_app_fs_entry(&apps_root, "myapp"),
+            FsEntryRemoval::Missing
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
 
     #[test]
     fn sanitize_dir_name() {

--- a/crates/coulson/src/service.rs
+++ b/crates/coulson/src/service.rs
@@ -55,50 +55,96 @@ pub fn app_get_by_id(state: &SharedState, app_id: i64) -> Result<AppSpec, Servic
     }
 }
 
-pub fn app_delete(state: &SharedState, app_id: i64) -> Result<(), ServiceError> {
-    let app = app_get_by_id(state, app_id)?;
-    // Snapshot per-app hooks before fs removal (which triggers watcher → clear_all_app_hooks)
-    let app_hooks_snapshot = state.hook_manager.take_app_hooks(app_id);
-    if let Some(ref fs_entry) = app.fs_entry {
-        scanner::remove_app_fs_entry(&state.apps_root, fs_entry);
-    }
-    let ctx = state
-        .hook_factory()
-        .context_for_app(HookEvent::AppRemove, &app);
-
-    let restore_hooks = |snapshot: Option<crate::hooks::AppHooksConfig>| {
-        if let Some(config) = snapshot {
-            state.hook_manager.register_app_hooks(app_id, config);
+pub async fn app_delete(state: &SharedState, app_id: i64) -> Result<(), ServiceError> {
+    // Row fetch+delete and process kill form one critical section under the
+    // PM lock, serializing deletion against the start paths (which validate
+    // the store row under the same lock before committing to a spawn): a
+    // start either completes fully before the delete — its group is killed
+    // here — or it revalidates after the row is gone and is refused. Nothing
+    // is mutated before the delete, so failures need no rollback.
+    let app;
+    let stopped;
+    {
+        let mut pm = state.process_manager.lock().await;
+        // Row delete and fs-entry removal commit as one write transaction:
+        // that pair is what a scan's in-transaction revalidation checks, so
+        // removing them non-atomically would let a stale discovery resurrect
+        // the app between the two steps. No awaits while the txn is alive.
+        {
+            let txn = match state.store.begin_write() {
+                Ok(txn) => txn,
+                Err(e) => return Err(ServiceError::Internal(e.to_string())),
+            };
+            // `delete_returning` snapshots and deletes in one statement — the
+            // scanner can rewrite the row in place, so cleanup and the
+            // AppRemove context must describe the row actually removed.
+            app = match txn.delete_returning(app_id) {
+                Ok(Some(app)) => app,
+                Ok(None) => return Err(ServiceError::NotFound),
+                Err(e) => return Err(ServiceError::Internal(e.to_string())),
+            };
+            // A Refused removal (directory, or fs error) aborts the delete:
+            // committing would leave the entry in place and the next scan
+            // would recreate the app — a success response that lies. The txn
+            // rolls back on drop, so nothing has changed. If the commit
+            // itself fails after a successful removal, the row rolls back
+            // while the entry is gone — the next scan prunes that row, so
+            // the state converges to deleted either way.
+            if let Some(ref fs_entry) = app.fs_entry {
+                if scanner::remove_app_fs_entry(&state.apps_root, fs_entry)
+                    == scanner::FsEntryRemoval::Refused
+                {
+                    return Err(ServiceError::Internal(format!(
+                        "apps_root entry '{fs_entry}' was not removed (directory or fs error); \
+                         a scan would recreate the app — remove the entry manually and retry"
+                    )));
+                }
+            }
+            if let Err(e) = txn.commit() {
+                return Err(ServiceError::Internal(e.to_string()));
+            }
         }
+        // The row is gone and ids are AUTOINCREMENT (never reused), so any
+        // group tracked under this id — whichever generation of the row
+        // started it, even one from before a managed→static rewrite — is
+        // stale: kill unconditionally (a no-op when no group exists). Quiet
+        // variant: the post-delete store lookup inside the normal AppStop
+        // path would miss the row and drop its route/tunnel fields, so the
+        // stop event is built below from the deleted snapshot instead, and
+        // sequenced before AppRemove.
+        stopped = pm.kill_process_quiet(app_id).await;
+    }
+    let factory = state.hook_factory();
+    // AppStop belongs to the generation that actually ran: context AND hooks
+    // come from the stopped group's spawn-time snapshot (the scanner can
+    // rewrite a row in place while an older generation is still running).
+    // AppRemove intentionally describes the deleted row — the generation the
+    // user removed.
+    let (stop_ctx, stop_hooks) = match stopped {
+        Some(s) => (
+            Some(factory.context_for_app(HookEvent::AppStop, &s.app_snapshot)),
+            s.app_snapshot.hooks,
+        ),
+        None => (None, None),
     };
+    let remove_ctx = factory.context_for_app(HookEvent::AppRemove, &app);
+    let remove_hooks = app.hooks.clone();
 
-    match state.store.delete(app_id) {
-        Ok(true) => {
-            state
-                .reload_routes()
-                .map_err(|e| ServiceError::Internal(e.to_string()))?;
-            // Stop the managed process group right away — nothing routes to it
-            // anymore, and the periodic orphan reconcile would only catch it
-            // on its next tick.
-            let pm = state.process_manager.clone();
-            tokio::spawn(async move {
-                pm.lock().await.kill_process(app_id).await;
-            });
-            let hm = state.hook_manager.clone();
-            tokio::spawn(async move {
-                hm.fire_with_hooks(&ctx, app_hooks_snapshot.as_ref()).await;
-            });
-            Ok(())
+    // Dispatch before the fallible route reload: the deletion is already
+    // committed, and these snapshots are the only source for its lifecycle
+    // events — an early return must not drop them. One task, sequential
+    // awaits: AppStop strictly precedes AppRemove.
+    let hm = state.hook_manager.clone();
+    tokio::spawn(async move {
+        if let Some(ctx) = stop_ctx {
+            hm.fire_with_hooks(&ctx, stop_hooks.as_ref()).await;
         }
-        Ok(false) => {
-            restore_hooks(app_hooks_snapshot);
-            Err(ServiceError::NotFound)
-        }
-        Err(e) => {
-            restore_hooks(app_hooks_snapshot);
-            Err(ServiceError::Internal(e.to_string()))
-        }
-    }
+        hm.fire_with_hooks(&remove_ctx, remove_hooks.as_ref()).await;
+    });
+    state
+        .reload_routes()
+        .map_err(|e| ServiceError::Internal(e.to_string()))?;
+    Ok(())
 }
 
 pub fn app_set_enabled(
@@ -122,14 +168,45 @@ pub fn app_set_enabled(
 pub fn fire_app_add_hooks(state: &SharedState, added_apps: &[crate::domain::AppSpec]) {
     for app in added_apps {
         let ctx = state.hook_factory().context_for_app(HookEvent::AppAdd, app);
+        let hooks = app.hooks.clone();
         let hm = state.hook_manager.clone();
-        tokio::spawn(async move { hm.fire(&ctx).await });
+        tokio::spawn(async move { hm.fire_with_hooks(&ctx, hooks.as_ref()).await });
     }
 }
 
-pub fn apps_scan(state: &SharedState) -> Result<ScanStats, ServiceError> {
+/// Stop processes belonging to scan-pruned rows and fire their `app_stop`
+/// hooks. The event is built entirely from the stopped group's spawn-time
+/// snapshot — the generation that actually ran — so an in-place row rewrite
+/// between spawn and prune cannot substitute another generation's context or
+/// hooks. Without this teardown, the reaper's reconcile would stop the
+/// process a tick later.
+pub async fn teardown_pruned_apps(state: &SharedState, pruned_apps: &[crate::domain::AppSpec]) {
+    for app in pruned_apps {
+        let killed = {
+            let mut pm = state.process_manager.lock().await;
+            pm.kill_process_quiet(app.id.0).await
+        };
+        let Some(stopped) = killed else {
+            continue;
+        };
+        let ctx = state
+            .hook_factory()
+            .context_for_app(HookEvent::AppStop, &stopped.app_snapshot);
+        let hooks = stopped.app_snapshot.hooks;
+        let hm = state.hook_manager.clone();
+        tokio::spawn(async move {
+            hm.fire_with_hooks(&ctx, hooks.as_ref()).await;
+        });
+    }
+}
+
+pub async fn apps_scan(state: &SharedState) -> Result<ScanStats, ServiceError> {
     let result =
         scanner::sync_from_apps_root(state).map_err(|e| ServiceError::Internal(e.to_string()))?;
+    // Consume the teardown snapshots first: the rows and hook registrations
+    // are already gone, so no fallible step (warnings write, route reload)
+    // may run before this or an early return would drop them.
+    teardown_pruned_apps(state, &result.pruned_apps).await;
     runtime::write_scan_warnings(&state.scan_warnings_path, &result.stats)
         .map_err(|e| ServiceError::Internal(e.to_string()))?;
     state
@@ -1049,8 +1126,9 @@ fn fire_tunnel_hook(
             ctx.app_urls.push(url.to_string());
         }
     }
+    let hooks = app.hooks.clone();
     let hm = state.hook_manager.clone();
-    tokio::spawn(async move { hm.fire(&ctx).await });
+    tokio::spawn(async move { hm.fire_with_hooks(&ctx, hooks.as_ref()).await });
 }
 
 /// Parse the first route target from a pow-format file content.

--- a/crates/coulson/src/service.rs
+++ b/crates/coulson/src/service.rs
@@ -77,6 +77,13 @@ pub fn app_delete(state: &SharedState, app_id: i64) -> Result<(), ServiceError> 
             state
                 .reload_routes()
                 .map_err(|e| ServiceError::Internal(e.to_string()))?;
+            // Stop the managed process group right away — nothing routes to it
+            // anymore, and the periodic orphan reconcile would only catch it
+            // on its next tick.
+            let pm = state.process_manager.clone();
+            tokio::spawn(async move {
+                pm.lock().await.kill_process(app_id).await;
+            });
             let hm = state.hook_manager.clone();
             tokio::spawn(async move {
                 hm.fire_with_hooks(&ctx, app_hooks_snapshot.as_ref()).await;

--- a/crates/coulson/src/service.rs
+++ b/crates/coulson/src/service.rs
@@ -122,7 +122,14 @@ pub async fn app_delete(state: &SharedState, app_id: i64) -> Result<(), ServiceE
     // user removed.
     let (stop_ctx, stop_hooks) = match stopped {
         Some(s) => (
-            Some(factory.context_for_app(HookEvent::AppStop, &s.app_snapshot)),
+            Some(factory.context_for_process(
+                HookEvent::AppStop,
+                app_id,
+                &s.name,
+                &s.root,
+                &s.kind,
+                Some(&s.app_snapshot),
+            )),
             s.app_snapshot.hooks,
         ),
         None => (None, None),
@@ -189,9 +196,14 @@ pub async fn teardown_pruned_apps(state: &SharedState, pruned_apps: &[crate::dom
         let Some(stopped) = killed else {
             continue;
         };
-        let ctx = state
-            .hook_factory()
-            .context_for_app(HookEvent::AppStop, &stopped.app_snapshot);
+        let ctx = state.hook_factory().context_for_process(
+            HookEvent::AppStop,
+            app.id.0,
+            &stopped.name,
+            &stopped.root,
+            &stopped.kind,
+            Some(&stopped.app_snapshot),
+        );
         let hooks = stopped.app_snapshot.hooks;
         let hm = state.hook_manager.clone();
         tokio::spawn(async move {
@@ -494,6 +506,7 @@ pub fn app_create_from_folder(state: &SharedState, path: &str) -> Result<AppSpec
         if let Some((_prov, detected)) = state
             .provider_registry
             .detect(folder, Some(&info.manifest_json))
+            .map_err(|e| ServiceError::Internal(e.to_string()))?
         {
             let root_str = folder.to_string_lossy().to_string();
             return insert_and_reload(state.store.insert_managed(
@@ -544,7 +557,11 @@ pub fn app_create_from_folder(state: &SharedState, path: &str) -> Result<AppSpec
     }
 
     // 3. Provider registry auto-detect
-    if let Some((_prov, detected)) = state.provider_registry.detect(folder, None) {
+    if let Some((_prov, detected)) = state
+        .provider_registry
+        .detect(folder, None)
+        .map_err(|e| ServiceError::Internal(e.to_string()))?
+    {
         let root_str = folder.to_string_lossy().to_string();
         return insert_and_reload(state.store.insert_managed(
             &name,

--- a/crates/coulson/src/share.rs
+++ b/crates/coulson/src/share.rs
@@ -117,6 +117,7 @@ mod tests {
     fn test_repo() -> AppRepository {
         let repo = AppRepository {
             conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
             domain_suffix: "test".to_string(),
             change_tx: None,
         };

--- a/crates/coulson/src/store/mod.rs
+++ b/crates/coulson/src/store/mod.rs
@@ -555,6 +555,22 @@ impl StoreTxn<'_> {
         Ok(())
     }
 
+    /// Read through the transaction's connection. Process startup uses this
+    /// while holding `BEGIN IMMEDIATE` across its final desired-state check and
+    /// in-memory group insertion, so an offline scanner cannot commit a prune
+    /// in the gap between those two operations.
+    pub fn get_by_id(&self, app_id: i64) -> anyhow::Result<Option<AppSpec>> {
+        let app = self
+            .conn
+            .query_row(
+                &format!("SELECT {} FROM apps WHERE id = ?1", COLS),
+                params![app_id],
+                |row| row_to_app(row, &self.repo.domain_suffix),
+            )
+            .optional()?;
+        Ok(app)
+    }
+
     pub fn upsert_scanned_static(
         &self,
         input: &StaticAppInput,

--- a/crates/coulson/src/store/mod.rs
+++ b/crates/coulson/src/store/mod.rs
@@ -41,6 +41,12 @@ pub struct StaticAppInput<'a> {
 
 pub struct AppRepository {
     pub(crate) conn: Mutex<Connection>,
+    /// Dedicated read connection (WAL mode): readers see the last committed
+    /// snapshot and never queue behind a long write transaction — store
+    /// reads taken under the process-manager lock must not stall for the
+    /// duration of a scan's `StoreTxn`. `None` for in-memory test databases
+    /// (falls back to the write connection).
+    pub(crate) read_conn: Option<Mutex<Connection>>,
     pub(crate) domain_suffix: String,
     pub(crate) change_tx: Option<broadcast::Sender<String>>,
 }
@@ -75,11 +81,31 @@ impl AppRepository {
         }
         let conn = Connection::open(path)
             .with_context(|| format!("failed to open sqlite db: {}", path.display()))?;
+        // Write transactions are taken by both the daemon and offline
+        // `coulson scan` against the same file; wait out the other side's
+        // BEGIN IMMEDIATE instead of failing with SQLITE_BUSY.
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        // WAL so the dedicated read connection below can read the last
+        // committed snapshot while a write transaction is open.
+        let _mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+        let read_conn = Connection::open(path)
+            .with_context(|| format!("failed to open sqlite db (read): {}", path.display()))?;
+        read_conn.busy_timeout(std::time::Duration::from_secs(5))?;
         Ok(Self {
             conn: Mutex::new(conn),
+            read_conn: Some(Mutex::new(read_conn)),
             domain_suffix: domain_suffix.to_string(),
             change_tx: None,
         })
+    }
+
+    /// Lock the read connection (or the write connection when no separate
+    /// reader exists, e.g. in-memory test databases).
+    fn reader(&self) -> parking_lot::MutexGuard<'_, Connection> {
+        match &self.read_conn {
+            Some(rc) => rc.lock(),
+            None => self.conn.lock(),
+        }
     }
 
     pub fn init_schema(&self) -> anyhow::Result<()> {
@@ -92,7 +118,7 @@ impl AppRepository {
             );
 
             CREATE TABLE IF NOT EXISTS apps (
-              id INTEGER PRIMARY KEY,
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
               name TEXT NOT NULL UNIQUE,
               kind TEXT NOT NULL,
               domain TEXT NOT NULL,
@@ -123,6 +149,7 @@ impl AppRepository {
               lan_access INTEGER NOT NULL DEFAULT 0,
               cname TEXT,
               fs_entry TEXT,
+              hooks TEXT,
               UNIQUE(domain, path_prefix)
             );
 
@@ -154,6 +181,12 @@ impl AppRepository {
             "#,
         )?;
 
+        // Structural v1 migration FIRST: it rebuilds `apps` from a hardcoded
+        // v1 column list, so it must run against the actual v1 shape. Running
+        // it after the additive columns below would silently drop every one
+        // of them from the rebuilt table.
+        migrate_apps_domain_unique_to_route_unique(&conn)?;
+
         // Migrations for databases created before all columns existed.
         // New databases already have every column via CREATE TABLE above,
         // so these are no-ops (add_column_if_missing silently skips).
@@ -176,11 +209,14 @@ impl AppRepository {
             "ALTER TABLE apps ADD COLUMN lan_access INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE apps ADD COLUMN cname TEXT",
             "ALTER TABLE apps ADD COLUMN fs_entry TEXT",
+            "ALTER TABLE apps ADD COLUMN hooks TEXT",
         ] {
             add_column_if_missing(&conn, sql)?;
         }
 
-        migrate_apps_domain_unique_to_route_unique(&conn)?;
+        // Runs last: rebuilds from the live sqlite_master schema text, so it
+        // preserves whatever columns exist at this point.
+        migrate_apps_id_autoincrement(&conn)?;
         Ok(())
     }
 
@@ -260,6 +296,7 @@ impl AppRepository {
             lan_access: false,
             cname: None,
             fs_entry: None,
+            hooks: None,
             enabled: true,
             created_at: now,
             updated_at: now,
@@ -332,6 +369,7 @@ impl AppRepository {
             lan_access: false,
             cname: None,
             fs_entry: None,
+            hooks: None,
             enabled: true,
             created_at: now,
             updated_at: now,
@@ -391,9 +429,29 @@ impl AppRepository {
             lan_access: false,
             cname: None,
             fs_entry: None,
+            hooks: None,
             enabled: true,
             created_at: now,
             updated_at: now,
+        })
+    }
+
+    /// Open a write transaction (`BEGIN IMMEDIATE`) that also holds the
+    /// in-process connection lock until commit or drop (rollback).
+    ///
+    /// "An app exists" spans a DB row plus an apps_root fs entry, and every
+    /// mutation of that pair — scan upsert/prune, explicit delete — runs
+    /// inside one of these. In-process the connection lock serializes them;
+    /// across processes (the daemon vs an offline `coulson scan`) SQLite's
+    /// write lock does, so checking the filesystem from inside a write
+    /// transaction observes a state no other party can be mutating.
+    pub fn begin_write(&self) -> anyhow::Result<StoreTxn<'_>> {
+        let conn = self.conn.lock();
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        Ok(StoreTxn {
+            repo: self,
+            conn,
+            committed: false,
         })
     }
 
@@ -403,11 +461,113 @@ impl AppRepository {
         enabled: bool,
         source: &str,
         fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
+    ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
+        let txn = self.begin_write()?;
+        let result = txn.upsert_scanned_static(input, enabled, source, fs_entry, hooks)?;
+        txn.commit()?;
+        Ok(result)
+    }
+
+    /// Upsert a managed (ASGI, Rack, Node, Docker, etc.) app discovered by the scanner.
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_scanned_managed(
+        &self,
+        name: &str,
+        domain: &DomainName,
+        app_root: &str,
+        kind: &str,
+        enabled: bool,
+        source: &str,
+        fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
+    ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
+        let txn = self.begin_write()?;
+        let result = txn.upsert_scanned_managed(
+            name, domain, app_root, kind, enabled, source, fs_entry, hooks,
+        )?;
+        txn.commit()?;
+        Ok(result)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_scanned_static_dir(
+        &self,
+        name: &str,
+        domain: &DomainName,
+        static_root: &str,
+        enabled: bool,
+        source: &str,
+        fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
+    ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
+        let txn = self.begin_write()?;
+        let result = txn.upsert_scanned_static_dir(
+            name,
+            domain,
+            static_root,
+            enabled,
+            source,
+            fs_entry,
+            hooks,
+        )?;
+        txn.commit()?;
+        Ok(result)
+    }
+
+    /// Remove scan-owned rows whose route disappeared, returning the removed
+    /// rows so the caller can tear down their processes and fire `app_stop`
+    /// hooks with full route context (after the delete, that data is gone).
+    /// Rows whose `fs_entry` is in `protected_fs_entries` are kept: their
+    /// entry exists but was unreadable this scan, which is not absence.
+    pub fn prune_scanned_not_in(
+        &self,
+        source: &str,
+        active_routes: &HashSet<String>,
+        protected_fs_entries: &HashSet<String>,
+    ) -> anyhow::Result<Vec<AppSpec>> {
+        let txn = self.begin_write()?;
+        let result = txn.prune_scanned_not_in(source, active_routes, protected_fs_entries)?;
+        txn.commit()?;
+        Ok(result)
+    }
+}
+
+/// See [`AppRepository::begin_write`].
+pub struct StoreTxn<'a> {
+    repo: &'a AppRepository,
+    conn: parking_lot::MutexGuard<'a, Connection>,
+    committed: bool,
+}
+
+impl Drop for StoreTxn<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            let _ = self.conn.execute_batch("ROLLBACK");
+        }
+    }
+}
+
+impl StoreTxn<'_> {
+    pub fn commit(mut self) -> anyhow::Result<()> {
+        self.conn.execute_batch("COMMIT")?;
+        self.committed = true;
+        Ok(())
+    }
+
+    pub fn upsert_scanned_static(
+        &self,
+        input: &StaticAppInput,
+        enabled: bool,
+        source: &str,
+        fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
     ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        let conn = self.conn.lock();
+        let hooks_json: Option<String> = hooks.map(serde_json::to_string).transpose()?;
+        let conn = &*self.conn;
         let path_prefix_db = path_prefix_to_db(input.path_prefix);
-        let domain_db = domain_to_db(&input.domain.0, &self.domain_suffix);
+        let domain_db = domain_to_db(&input.domain.0, &self.repo.domain_suffix);
 
         let existing: Option<(i64, i64)> = conn
             .query_row(
@@ -421,7 +581,7 @@ impl AppRepository {
             Some((_id, 0)) => ScanUpsertResult::SkippedManual,
             Some((id, _)) => {
                 conn.execute(
-                    "UPDATE apps SET name = ?1, path_prefix = ?2, target_type = ?3, target_value = ?4, timeout_ms = ?5, updated_at = ?6, scan_managed = 1, scan_source = ?7, cors_enabled = ?8, force_https = ?9, basic_auth_user = ?10, basic_auth_pass = ?11, spa_rewrite = ?12, listen_port = ?13, fs_entry = ?14, enabled = ?15 WHERE id = ?16",
+                    "UPDATE apps SET name = ?1, path_prefix = ?2, target_type = ?3, target_value = ?4, timeout_ms = ?5, updated_at = ?6, scan_managed = 1, scan_source = ?7, cors_enabled = ?8, force_https = ?9, basic_auth_user = ?10, basic_auth_pass = ?11, spa_rewrite = ?12, listen_port = ?13, fs_entry = ?14, enabled = ?15, hooks = ?17 WHERE id = ?16",
                     params![
                         input.name,
                         path_prefix_db,
@@ -438,15 +598,16 @@ impl AppRepository {
                         input.listen_port.map(|v| v as i64),
                         fs_entry,
                         if enabled { 1 } else { 0 },
-                        id
+                        id,
+                        hooks_json
                     ],
                 )?;
                 ScanUpsertResult::Updated
             }
             None => {
                 conn.execute(
-                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, cors_enabled, force_https, basic_auth_user, basic_auth_pass, spa_rewrite, listen_port, fs_entry)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, cors_enabled, force_https, basic_auth_user, basic_auth_pass, spa_rewrite, listen_port, fs_entry, hooks)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                     params![
                         input.name,
                         "static",
@@ -466,18 +627,18 @@ impl AppRepository {
                         if input.spa_rewrite { 1 } else { 0 },
                         input.listen_port.map(|v| v as i64),
                         fs_entry,
+                        hooks_json,
                     ],
                 )?;
                 ScanUpsertResult::Inserted
             }
         };
 
-        let suffix = &self.domain_suffix;
-        let app = Self::read_app_by_route(&conn, &domain_db, &path_prefix_db, suffix)?;
+        let suffix = &self.repo.domain_suffix;
+        let app = AppRepository::read_app_by_route(conn, &domain_db, &path_prefix_db, suffix)?;
         Ok((app, op))
     }
 
-    /// Upsert a managed (ASGI, Rack, Node, Docker, etc.) app discovered by the scanner.
     #[allow(clippy::too_many_arguments)]
     pub fn upsert_scanned_managed(
         &self,
@@ -488,11 +649,13 @@ impl AppRepository {
         enabled: bool,
         source: &str,
         fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
     ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        let conn = self.conn.lock();
+        let hooks_json: Option<String> = hooks.map(serde_json::to_string).transpose()?;
+        let conn = &*self.conn;
         let path_prefix_db = "";
-        let domain_db = domain_to_db(&domain.0, &self.domain_suffix);
+        let domain_db = domain_to_db(&domain.0, &self.repo.domain_suffix);
 
         let existing: Option<(i64, i64)> = conn
             .query_row(
@@ -506,15 +669,15 @@ impl AppRepository {
             Some((_id, 0)) => ScanUpsertResult::SkippedManual,
             Some((id, _)) => {
                 conn.execute(
-                    "UPDATE apps SET name = ?1, kind = ?2, target_type = 'managed', target_value = ?3, updated_at = ?4, scan_managed = 1, scan_source = ?5, fs_entry = ?6, enabled = ?7 WHERE id = ?8",
-                    params![name, kind, app_root, now, source, fs_entry, if enabled { 1 } else { 0 }, id],
+                    "UPDATE apps SET name = ?1, kind = ?2, target_type = 'managed', target_value = ?3, updated_at = ?4, scan_managed = 1, scan_source = ?5, fs_entry = ?6, enabled = ?7, hooks = ?9 WHERE id = ?8",
+                    params![name, kind, app_root, now, source, fs_entry, if enabled { 1 } else { 0 }, id, hooks_json],
                 )?;
                 ScanUpsertResult::Updated
             }
             None => {
                 conn.execute(
-                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, fs_entry)
-                     VALUES (?1, ?2, ?3, ?4, 'managed', ?5, NULL, ?6, 1, ?7, ?8, ?9, ?10)",
+                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, fs_entry, hooks)
+                     VALUES (?1, ?2, ?3, ?4, 'managed', ?5, NULL, ?6, 1, ?7, ?8, ?9, ?10, ?11)",
                     params![
                         name,
                         kind,
@@ -526,17 +689,19 @@ impl AppRepository {
                         now,
                         now,
                         fs_entry,
+                        hooks_json,
                     ],
                 )?;
                 ScanUpsertResult::Inserted
             }
         };
 
-        let suffix = &self.domain_suffix;
-        let app = Self::read_app_by_route(&conn, &domain_db, path_prefix_db, suffix)?;
+        let suffix = &self.repo.domain_suffix;
+        let app = AppRepository::read_app_by_route(conn, &domain_db, path_prefix_db, suffix)?;
         Ok((app, op))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn upsert_scanned_static_dir(
         &self,
         name: &str,
@@ -545,11 +710,13 @@ impl AppRepository {
         enabled: bool,
         source: &str,
         fs_entry: &str,
+        hooks: Option<&crate::hooks::AppHooksConfig>,
     ) -> anyhow::Result<(AppSpec, ScanUpsertResult)> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        let conn = self.conn.lock();
+        let hooks_json: Option<String> = hooks.map(serde_json::to_string).transpose()?;
+        let conn = &*self.conn;
         let path_prefix_db = "";
-        let domain_db = domain_to_db(&domain.0, &self.domain_suffix);
+        let domain_db = domain_to_db(&domain.0, &self.repo.domain_suffix);
 
         let existing: Option<(i64, i64)> = conn
             .query_row(
@@ -563,15 +730,15 @@ impl AppRepository {
             Some((_id, 0)) => ScanUpsertResult::SkippedManual,
             Some((id, _)) => {
                 conn.execute(
-                    "UPDATE apps SET name = ?1, kind = 'static', target_type = 'static_dir', target_value = ?2, updated_at = ?3, scan_managed = 1, scan_source = ?4, fs_entry = ?5, enabled = ?6 WHERE id = ?7",
-                    params![name, static_root, now, source, fs_entry, if enabled { 1 } else { 0 }, id],
+                    "UPDATE apps SET name = ?1, kind = 'static', target_type = 'static_dir', target_value = ?2, updated_at = ?3, scan_managed = 1, scan_source = ?4, fs_entry = ?5, enabled = ?6, hooks = ?8 WHERE id = ?7",
+                    params![name, static_root, now, source, fs_entry, if enabled { 1 } else { 0 }, id, hooks_json],
                 )?;
                 ScanUpsertResult::Updated
             }
             None => {
                 conn.execute(
-                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, fs_entry)
-                     VALUES (?1, 'static', ?2, ?3, 'static_dir', ?4, NULL, ?5, 1, ?6, ?7, ?8, ?9)",
+                    "INSERT INTO apps (name, kind, domain, path_prefix, target_type, target_value, timeout_ms, enabled, scan_managed, scan_source, created_at, updated_at, fs_entry, hooks)
+                     VALUES (?1, 'static', ?2, ?3, 'static_dir', ?4, NULL, ?5, 1, ?6, ?7, ?8, ?9, ?10)",
                     params![
                         name,
                         domain_db,
@@ -582,14 +749,15 @@ impl AppRepository {
                         now,
                         now,
                         fs_entry,
+                        hooks_json,
                     ],
                 )?;
                 ScanUpsertResult::Inserted
             }
         };
 
-        let suffix = &self.domain_suffix;
-        let app = Self::read_app_by_route(&conn, &domain_db, path_prefix_db, suffix)?;
+        let suffix = &self.repo.domain_suffix;
+        let app = AppRepository::read_app_by_route(conn, &domain_db, path_prefix_db, suffix)?;
         Ok((app, op))
     }
 
@@ -597,10 +765,11 @@ impl AppRepository {
         &self,
         source: &str,
         active_routes: &HashSet<String>,
-    ) -> anyhow::Result<usize> {
-        let conn = self.conn.lock();
+        protected_fs_entries: &HashSet<String>,
+    ) -> anyhow::Result<Vec<AppSpec>> {
+        let conn = &*self.conn;
         let mut stmt = conn.prepare(
-            "SELECT id, domain, path_prefix FROM apps WHERE scan_managed = 1 AND scan_source = ?1",
+            "SELECT id, domain, path_prefix, fs_entry FROM apps WHERE scan_managed = 1 AND scan_source = ?1",
         )?;
         let mut rows = stmt.query(params![source])?;
         let mut delete_ids: Vec<i64> = Vec::new();
@@ -609,23 +778,66 @@ impl AppRepository {
             let id: i64 = row.get(0)?;
             let domain_prefix: String = row.get(1)?;
             let path_prefix: String = row.get(2)?;
+            let fs_entry: Option<String> = row.get(3)?;
+            if fs_entry
+                .as_deref()
+                .is_some_and(|e| protected_fs_entries.contains(e))
+            {
+                continue;
+            }
             let key = route_key(&domain_prefix, &path_prefix);
             if !active_routes.contains(&key) {
                 delete_ids.push(id);
             }
         }
 
-        let mut deleted = 0usize;
+        let mut pruned = Vec::new();
         for id in &delete_ids {
-            deleted += conn.execute("DELETE FROM apps WHERE id = ?1", params![id])?;
+            let app = conn
+                .query_row(
+                    &format!("DELETE FROM apps WHERE id = ?1 RETURNING {}", COLS),
+                    params![id],
+                    |row| row_to_app(row, &self.repo.domain_suffix),
+                )
+                .optional()?;
+            if let Some(app) = app {
+                pruned.push(app);
+            }
         }
-        Ok(deleted)
+        Ok(pruned)
     }
 
+    /// Delete the row and return the removed snapshot in a single
+    /// `DELETE … RETURNING` statement — the scanner can rewrite a row in
+    /// place, so cleanup (hooks, fs entry) must describe the row actually
+    /// removed, not a separately fetched copy.
+    pub fn delete_returning(&self, app_id: i64) -> anyhow::Result<Option<AppSpec>> {
+        let conn = &*self.conn;
+        let app = conn
+            .query_row(
+                &format!("DELETE FROM apps WHERE id = ?1 RETURNING {}", COLS),
+                params![app_id],
+                |row| row_to_app(row, &self.repo.domain_suffix),
+            )
+            .optional()?;
+        Ok(app)
+    }
+}
+
+impl AppRepository {
     pub fn delete(&self, app_id: i64) -> anyhow::Result<bool> {
         let conn = self.conn.lock();
         let changed = conn.execute("DELETE FROM apps WHERE id = ?1", params![app_id])?;
         Ok(changed > 0)
+    }
+
+    /// Transactional variant of [`StoreTxn::delete_returning`] for callers
+    /// that have no fs entry to remove alongside the row.
+    pub fn delete_returning(&self, app_id: i64) -> anyhow::Result<Option<AppSpec>> {
+        let txn = self.begin_write()?;
+        let app = txn.delete_returning(app_id)?;
+        txn.commit()?;
+        Ok(app)
     }
 
     pub fn set_enabled(&self, app_id: i64, enabled: bool) -> anyhow::Result<bool> {
@@ -642,7 +854,7 @@ impl AppRepository {
     }
 
     pub fn list_all(&self) -> anyhow::Result<Vec<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         Self::query_apps(&conn, false, &self.domain_suffix)
     }
 
@@ -652,12 +864,12 @@ impl AppRepository {
         domain: Option<&str>,
     ) -> anyhow::Result<Vec<AppSpec>> {
         let domain_db = domain.map(|d| domain_to_db(d, &self.domain_suffix));
-        let conn = self.conn.lock();
+        let conn = self.reader();
         Self::query_apps_filtered(&conn, managed, domain_db.as_deref(), &self.domain_suffix)
     }
 
     pub fn list_enabled(&self) -> anyhow::Result<Vec<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         Self::query_apps(&conn, true, &self.domain_suffix)
     }
 
@@ -740,7 +952,7 @@ impl AppRepository {
     }
 
     pub fn get_setting(&self, key: &str) -> anyhow::Result<Option<String>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let value = conn
             .query_row(
                 "SELECT value FROM settings WHERE key = ?1",
@@ -816,7 +1028,7 @@ impl AppRepository {
     }
 
     pub fn list_app_tunnels(&self) -> anyhow::Result<Vec<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let sql = format!(
             "SELECT {} FROM apps WHERE tunnel_mode = 'named' AND enabled = 1",
             COLS
@@ -827,7 +1039,7 @@ impl AppRepository {
     }
 
     pub fn list_quick_tunnels(&self) -> anyhow::Result<Vec<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let sql = format!(
             "SELECT {} FROM apps WHERE tunnel_mode = 'quick' AND enabled = 1",
             COLS
@@ -838,7 +1050,7 @@ impl AppRepository {
     }
 
     pub fn is_tunnel_exposed(&self, domain_prefix: &str) -> anyhow::Result<bool> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM apps WHERE domain = ?1 AND enabled = 1 AND tunnel_mode != 'none'",
             params![domain_prefix],
@@ -848,7 +1060,7 @@ impl AppRepository {
     }
 
     pub fn is_share_auth_required(&self, domain_prefix: &str) -> anyhow::Result<bool> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM apps WHERE domain = ?1 AND enabled = 1 AND share_auth = 1",
             params![domain_prefix],
@@ -868,7 +1080,7 @@ impl AppRepository {
     }
 
     pub fn get_by_id(&self, app_id: i64) -> anyhow::Result<Option<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let app = conn
             .query_row(
                 &format!("SELECT {} FROM apps WHERE id = ?1", COLS),
@@ -880,7 +1092,7 @@ impl AppRepository {
     }
 
     pub fn get_by_name(&self, name: &str) -> anyhow::Result<Option<AppSpec>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let app = conn
             .query_row(
                 &format!("SELECT {} FROM apps WHERE name = ?1", COLS),
@@ -1014,7 +1226,7 @@ impl AppRepository {
         app_id: i64,
         limit: usize,
     ) -> anyhow::Result<Vec<CapturedRequest>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let mut stmt = conn.prepare(
             "SELECT id, app_id, timestamp, method, path, query_string, request_headers, request_body, status_code, response_headers, response_body, response_time_ms FROM request_logs WHERE app_id = ? ORDER BY timestamp DESC LIMIT ?",
         )?;
@@ -1027,7 +1239,7 @@ impl AppRepository {
     }
 
     pub fn get_request_log(&self, req_id: &str) -> anyhow::Result<Option<CapturedRequest>> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let mut stmt = conn.prepare(
             "SELECT id, app_id, timestamp, method, path, query_string, request_headers, request_body, status_code, response_headers, response_body, response_time_ms FROM request_logs WHERE id = ?",
         )?;
@@ -1047,7 +1259,7 @@ impl AppRepository {
         let app = self.get_by_name(app_name)?;
         match app {
             Some(app) => {
-                let conn = self.conn.lock();
+                let conn = self.reader();
                 let mut stmt = conn.prepare(
                     "SELECT id, app_id, timestamp, method, path, query_string, request_headers, request_body, status_code, response_headers, response_body, response_time_ms FROM request_logs WHERE app_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?",
                 )?;
@@ -1075,7 +1287,7 @@ impl AppRepository {
     }
 
     pub fn count_request_logs(&self, app_id: i64) -> anyhow::Result<usize> {
-        let conn = self.conn.lock();
+        let conn = self.reader();
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM request_logs WHERE app_id = ?",
             params![app_id],
@@ -1085,7 +1297,7 @@ impl AppRepository {
     }
 }
 
-const COLS: &str = "id,name,kind,domain,path_prefix,target_type,target_value,timeout_ms,enabled,created_at,updated_at,cors_enabled,force_https,basic_auth_user,basic_auth_pass,spa_rewrite,listen_port,tunnel_url,tunnel_mode,app_tunnel_id,app_tunnel_domain,app_tunnel_dns_id,app_tunnel_creds,inspect_enabled,lan_access,cname,fs_entry";
+const COLS: &str = "id,name,kind,domain,path_prefix,target_type,target_value,timeout_ms,enabled,created_at,updated_at,cors_enabled,force_https,basic_auth_user,basic_auth_pass,spa_rewrite,listen_port,tunnel_url,tunnel_mode,app_tunnel_id,app_tunnel_domain,app_tunnel_dns_id,app_tunnel_creds,inspect_enabled,lan_access,cname,fs_entry,hooks";
 
 fn backend_target_from_db(
     id: i64,
@@ -1184,6 +1396,10 @@ fn row_to_app(row: &rusqlite::Row<'_>, suffix: &str) -> rusqlite::Result<AppSpec
         lan_access: row.get::<_, i64>(24).unwrap_or(0) == 1,
         cname: row.get::<_, Option<String>>(25).unwrap_or(None),
         fs_entry: row.get::<_, Option<String>>(26).unwrap_or(None),
+        hooks: row
+            .get::<_, Option<String>>(27)
+            .unwrap_or(None)
+            .and_then(|raw| serde_json::from_str(&raw).ok()),
     })
 }
 
@@ -1284,6 +1500,75 @@ fn migrate_apps_domain_unique_to_route_unique(conn: &Connection) -> anyhow::Resu
     Ok(())
 }
 
+/// Rebuild `apps` with `AUTOINCREMENT` so row ids are never reused after
+/// deletion. Without it SQLite hands a deleted maximum id to the next insert,
+/// and every consumer keyed by app_id (process groups, per-app hooks, routes)
+/// can confuse the replacement app with the removed one. Identity checks
+/// remain as defense in depth, but monotonic ids remove the class of races.
+///
+/// The new table is derived from the live `sqlite_master` text (not a
+/// hard-coded column list), so it works for any column set the migrations
+/// have produced so far.
+fn migrate_apps_id_autoincrement(conn: &Connection) -> anyhow::Result<()> {
+    let table_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'apps'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(sql) = table_sql else {
+        return Ok(());
+    };
+    if sql.to_uppercase().contains("AUTOINCREMENT") {
+        return Ok(());
+    }
+
+    let with_autoinc = sql.replacen(
+        "id INTEGER PRIMARY KEY",
+        "id INTEGER PRIMARY KEY AUTOINCREMENT",
+        1,
+    );
+    let create_new = if with_autoinc.contains("CREATE TABLE IF NOT EXISTS apps") {
+        with_autoinc.replacen(
+            "CREATE TABLE IF NOT EXISTS apps",
+            "CREATE TABLE apps_new",
+            1,
+        )
+    } else {
+        with_autoinc.replacen("CREATE TABLE apps", "CREATE TABLE apps_new", 1)
+    };
+    if create_new == sql || !create_new.contains("AUTOINCREMENT") {
+        // Unexpected schema text: skip rather than brick startup; identity
+        // checks still guard against id reuse.
+        tracing::error!("apps table schema not recognized, skipping AUTOINCREMENT migration");
+        return Ok(());
+    }
+
+    let mut cols: Vec<String> = Vec::new();
+    let mut stmt = conn.prepare("PRAGMA table_info(apps)")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for col in rows {
+        cols.push(col?);
+    }
+    drop(stmt);
+    let col_list = cols.join(", ");
+
+    conn.execute_batch(&format!(
+        r#"
+        BEGIN;
+        {create_new};
+        INSERT INTO apps_new ({col_list}) SELECT {col_list} FROM apps;
+        DROP TABLE apps;
+        ALTER TABLE apps_new RENAME TO apps;
+        CREATE INDEX IF NOT EXISTS idx_apps_enabled_domain ON apps(enabled, domain);
+        COMMIT;
+        "#
+    ))?;
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // CapturedRequest model
 // ---------------------------------------------------------------------------
@@ -1329,6 +1614,7 @@ mod tests {
     fn insert_and_list_enabled() {
         let repo = AppRepository {
             conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
             domain_suffix: "coulson.local".to_string(),
             change_tx: None,
         };
@@ -1359,6 +1645,7 @@ mod tests {
     fn rescan_applies_enabled_change_to_managed_route() {
         let repo = AppRepository {
             conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
             domain_suffix: "coulson.local".to_string(),
             change_tx: None,
         };
@@ -1367,23 +1654,511 @@ mod tests {
 
         // First scan: enabled
         let (app, op) = repo
-            .upsert_scanned_managed("myapp", &domain, "/srv/myapp", "asgi", true, "fs", "entry")
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                "/srv/myapp",
+                "asgi",
+                true,
+                "fs",
+                "entry",
+                None,
+            )
             .expect("first upsert");
         assert!(matches!(op, ScanUpsertResult::Inserted));
         assert!(app.enabled);
 
         // Rescan with enabled = false must flip the stored state.
         let (app, op) = repo
-            .upsert_scanned_managed("myapp", &domain, "/srv/myapp", "asgi", false, "fs", "entry")
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                "/srv/myapp",
+                "asgi",
+                false,
+                "fs",
+                "entry",
+                None,
+            )
             .expect("second upsert");
         assert!(matches!(op, ScanUpsertResult::Updated));
         assert!(!app.enabled);
     }
 
     #[test]
+    fn deleted_app_ids_are_never_reused() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+
+        let domain = DomainName("appx.coulson.local".to_string());
+        let (a, _) = repo
+            .upsert_scanned_managed(
+                "appx",
+                &domain,
+                "/srv/appx",
+                "procfile",
+                true,
+                "fs",
+                "e",
+                None,
+            )
+            .expect("insert appx");
+        assert!(repo.delete(a.id.0).expect("delete appx"));
+
+        // The table is now empty; without AUTOINCREMENT the next insert would
+        // reuse appx's id and every app_id-keyed consumer could confuse the
+        // replacement with the removed app.
+        let domain2 = DomainName("appy.coulson.local".to_string());
+        let (b, _) = repo
+            .upsert_scanned_managed(
+                "appy",
+                &domain2,
+                "/srv/appy",
+                "procfile",
+                true,
+                "fs",
+                "e",
+                None,
+            )
+            .expect("insert appy");
+        assert!(b.id.0 > a.id.0, "row id reused after delete");
+    }
+
+    #[test]
+    fn hooks_persist_on_row_and_survive_delete_returning() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain = DomainName("myapp.coulson.local".to_string());
+
+        let hooks = crate::hooks::AppHooksConfig {
+            skip_global: true,
+            app_stop: Some(crate::hooks::HookActionConfig {
+                run: Some("echo stopped".to_string()),
+                webhook: None,
+            }),
+            app_add: None,
+            app_remove: None,
+            app_start: None,
+            app_ready: None,
+            app_idle: None,
+            tunnel_start: None,
+            tunnel_stop: None,
+        };
+        let (app, _) = repo
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                "/srv/myapp",
+                "asgi",
+                true,
+                "fs",
+                "e",
+                Some(&hooks),
+            )
+            .expect("upsert");
+        // The row is the single source of truth: reads and the deletion
+        // snapshot must both carry the hook config of this generation.
+        let read = repo.get_by_id(app.id.0).expect("get").expect("row");
+        assert!(read.hooks.as_ref().is_some_and(|h| h.skip_global));
+        let deleted = repo
+            .delete_returning(app.id.0)
+            .expect("delete")
+            .expect("row existed");
+        let dh = deleted.hooks.expect("hooks on deleted snapshot");
+        assert_eq!(
+            dh.app_stop.and_then(|a| a.run).as_deref(),
+            Some("echo stopped")
+        );
+    }
+
+    #[test]
+    fn app_spec_serialization_omits_hooks() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain = DomainName("myapp.coulson.local".to_string());
+        let hooks = crate::hooks::AppHooksConfig {
+            skip_global: false,
+            app_stop: Some(crate::hooks::HookActionConfig {
+                run: Some("curl -H 'Authorization: Bearer secret'".to_string()),
+                webhook: Some("https://example.com/?sig=secret".to_string()),
+            }),
+            app_add: None,
+            app_remove: None,
+            app_start: None,
+            app_ready: None,
+            app_idle: None,
+            tunnel_start: None,
+            tunnel_stop: None,
+        };
+        let (app, _) = repo
+            .upsert_scanned_managed(
+                "myapp",
+                &domain,
+                "/srv/myapp",
+                "asgi",
+                true,
+                "fs",
+                "e",
+                Some(&hooks),
+            )
+            .expect("upsert");
+        repo.update_settings(
+            app.id.0,
+            None,
+            None,
+            None,
+            Some(Some("s3cret-pw")),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("set basic auth pass");
+        repo.set_app_tunnel_state(
+            app.id.0,
+            Some("tid"),
+            Some("t.example.com"),
+            None,
+            Some("{\"tunnel_secret\":\"s3cret-tunnel\"}"),
+            TunnelMode::Named,
+        )
+        .expect("set tunnel creds");
+        let read = repo.get_by_id(app.id.0).expect("get").expect("row");
+        assert!(read.hooks.is_some(), "hooks must round-trip via the store");
+        assert!(read.basic_auth_pass.is_some());
+        assert!(read.app_tunnel_creds.is_some());
+
+        // AppSpec flows out through control RPC (`app.list`/`app.get`); hook
+        // commands/webhook URLs, the basic-auth password, and the tunnel
+        // credential JSON can all carry secrets and must never appear in any
+        // serialized form — secrets serialize as presence booleans only.
+        let json = serde_json::to_value(&read).expect("serialize");
+        assert!(json.get("hooks").is_none(), "hooks leaked: {json}");
+        assert!(json.get("basic_auth_pass").is_none());
+        assert!(json.get("app_tunnel_creds").is_none());
+        assert_eq!(
+            json.get("basic_auth_pass_set").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            json.get("app_tunnel_creds_set").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert!(!json.to_string().contains("secret"));
+        assert!(!json.to_string().contains("s3cret"));
+    }
+
+    #[test]
+    fn prune_keeps_rows_of_protected_fs_entries() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain = DomainName("appx.coulson.local".to_string());
+        repo.upsert_scanned_managed(
+            "appx",
+            &domain,
+            "/srv/appx",
+            "asgi",
+            true,
+            "apps_root",
+            "appx",
+            None,
+        )
+        .expect("seed");
+
+        // Route absent from active_routes, but its fs entry is indeterminate
+        // (unreadable this scan): the row must survive the prune.
+        let mut protected = HashSet::new();
+        protected.insert("appx".to_string());
+        let pruned = repo
+            .prune_scanned_not_in("apps_root", &HashSet::new(), &protected)
+            .expect("prune protected");
+        assert!(pruned.is_empty());
+        assert!(repo.get_by_name("appx").expect("get").is_some());
+
+        // Without protection the same prune removes it.
+        let pruned = repo
+            .prune_scanned_not_in("apps_root", &HashSet::new(), &HashSet::new())
+            .expect("prune");
+        assert_eq!(pruned.len(), 1);
+        assert!(repo.get_by_name("appx").expect("get").is_none());
+    }
+
+    #[test]
+    fn store_txn_rolls_back_on_drop() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain = DomainName("appx.coulson.local".to_string());
+
+        {
+            let txn = repo.begin_write().expect("begin");
+            txn.upsert_scanned_managed("appx", &domain, "/srv/appx", "asgi", true, "fs", "e", None)
+                .expect("upsert");
+            // Dropped without commit — a scan that errors out halfway must
+            // leave no partially applied rows behind.
+        }
+        assert!(repo.get_by_name("appx").expect("get").is_none());
+    }
+
+    #[test]
+    fn store_txn_commits_multiple_ops_atomically() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain_a = DomainName("appa.coulson.local".to_string());
+        let domain_b = DomainName("appb.coulson.local".to_string());
+        repo.upsert_scanned_managed(
+            "appa",
+            &domain_a,
+            "/srv/appa",
+            "asgi",
+            true,
+            "apps_root",
+            "a",
+            None,
+        )
+        .expect("seed appa");
+
+        // One transaction: upsert appb, prune appa (route disappeared).
+        let txn = repo.begin_write().expect("begin");
+        txn.upsert_scanned_managed(
+            "appb",
+            &domain_b,
+            "/srv/appb",
+            "node",
+            true,
+            "apps_root",
+            "b",
+            None,
+        )
+        .expect("upsert appb");
+        let mut active = HashSet::new();
+        active.insert(route_key("appb", ""));
+        let pruned = txn
+            .prune_scanned_not_in("apps_root", &active, &HashSet::new())
+            .expect("prune");
+        txn.commit().expect("commit");
+
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0].name, "appa");
+        assert!(repo.get_by_name("appa").expect("get").is_none());
+        assert!(repo.get_by_name("appb").expect("get").is_some());
+    }
+
+    #[test]
+    fn delete_returning_snapshots_the_row_it_removes() {
+        let repo = AppRepository {
+            conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("schema");
+        let domain = DomainName("myapp.coulson.local".to_string());
+
+        let (a, _) = repo
+            .upsert_scanned_managed("myapp", &domain, "/srv/a", "node", true, "fs", "e", None)
+            .expect("insert");
+        // In-place scanner rewrite: same route key keeps the row id but
+        // changes identity (root + provider kind).
+        let (b, op) = repo
+            .upsert_scanned_managed(
+                "myapp", &domain, "/srv/b", "procfile", true, "fs", "e", None,
+            )
+            .expect("rewrite");
+        assert!(matches!(op, ScanUpsertResult::Updated));
+        assert_eq!(a.id.0, b.id.0);
+
+        // The returned snapshot must be the rewritten row, not a stale fetch.
+        let deleted = repo
+            .delete_returning(b.id.0)
+            .expect("delete")
+            .expect("row existed");
+        match deleted.target {
+            BackendTarget::Managed {
+                ref root, ref kind, ..
+            } => {
+                assert_eq!(root, "/srv/b");
+                assert_eq!(kind, "procfile");
+            }
+            ref other => panic!("unexpected target: {other:?}"),
+        }
+        assert!(repo.get_by_id(b.id.0).expect("get").is_none());
+        // Missing row → None, nothing deleted.
+        assert!(repo
+            .delete_returning(b.id.0)
+            .expect("second delete")
+            .is_none());
+    }
+
+    #[test]
+    fn migrate_v1_domain_unique_schema_preserves_modern_columns() {
+        let conn = Connection::open_in_memory().expect("open sqlite");
+        // The actual v1 schema: `domain UNIQUE`, host/port target columns,
+        // none of the later additive columns.
+        conn.execute_batch(
+            r#"
+            CREATE TABLE apps (
+              id INTEGER PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              kind TEXT NOT NULL,
+              domain TEXT NOT NULL UNIQUE,
+              target_host TEXT,
+              target_port INTEGER,
+              enabled INTEGER NOT NULL,
+              scan_managed INTEGER NOT NULL DEFAULT 0,
+              scan_source TEXT,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL
+            );
+            INSERT INTO apps (id, name, kind, domain, target_host, target_port, enabled, created_at, updated_at)
+            VALUES (3, 'v1app', 'static', 'v1app', '127.0.0.1', 5006, 1, 0, 0);
+            "#,
+        )
+        .expect("v1 schema");
+        let repo = AppRepository {
+            conn: Mutex::new(conn),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        // The v1 rebuild must run before the additive-column migrations, or
+        // it silently drops every modern column from the rebuilt table.
+        repo.init_schema().expect("migrate");
+
+        // Full COLS read works (would fail with `no such column` if the
+        // rebuild truncated the schema) and the row content survived.
+        let app = repo.get_by_id(3).expect("get").expect("row preserved");
+        assert_eq!(app.name, "v1app");
+        assert_eq!(app.domain.0, "v1app.coulson.local");
+        assert!(app.hooks.is_none());
+
+        // Modern columns are writable — hooks persistence works end to end.
+        let domain = DomainName("hooked.coulson.local".to_string());
+        let hooks = crate::hooks::AppHooksConfig {
+            skip_global: true,
+            app_add: None,
+            app_remove: None,
+            app_start: None,
+            app_ready: None,
+            app_stop: None,
+            app_idle: None,
+            tunnel_start: None,
+            tunnel_stop: None,
+        };
+        let (created, _) = repo
+            .upsert_scanned_managed(
+                "hooked",
+                &domain,
+                "/srv/hooked",
+                "asgi",
+                true,
+                "fs",
+                "e",
+                Some(&hooks),
+            )
+            .expect("upsert on migrated schema");
+        let read = repo.get_by_id(created.id.0).expect("get").expect("row");
+        assert!(read.hooks.is_some_and(|h| h.skip_global));
+    }
+
+    #[test]
+    fn migrate_apps_id_autoincrement_rebuilds_and_preserves_rows() {
+        let conn = Connection::open_in_memory().expect("open sqlite");
+        // Simulate a pre-AUTOINCREMENT database with the route-unique schema.
+        conn.execute_batch(
+            r#"
+            CREATE TABLE apps (
+              id INTEGER PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              kind TEXT NOT NULL,
+              domain TEXT NOT NULL,
+              path_prefix TEXT NOT NULL DEFAULT '',
+              target_type TEXT NOT NULL DEFAULT 'tcp',
+              target_value TEXT NOT NULL DEFAULT '',
+              timeout_ms INTEGER,
+              enabled INTEGER NOT NULL,
+              scan_managed INTEGER NOT NULL DEFAULT 0,
+              scan_source TEXT,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL,
+              UNIQUE(domain, path_prefix)
+            );
+            INSERT INTO apps (id, name, kind, domain, enabled, created_at, updated_at)
+            VALUES (7, 'legacy', 'asgi', 'legacy', 1, 0, 0);
+            "#,
+        )
+        .expect("legacy schema");
+        let repo = AppRepository {
+            conn: Mutex::new(conn),
+            read_conn: None,
+            domain_suffix: "coulson.local".to_string(),
+            change_tx: None,
+        };
+        repo.init_schema().expect("migrate");
+
+        let conn = repo.conn.lock();
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'apps'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("table sql");
+        assert!(sql.contains("AUTOINCREMENT"), "apps not rebuilt: {sql}");
+        let (id, name): (i64, String) = conn
+            .query_row("SELECT id, name FROM apps", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .expect("row preserved");
+        assert_eq!((id, name.as_str()), (7, "legacy"));
+        // The sequence continues above the migrated max id.
+        conn.execute(
+            "INSERT INTO apps (name, kind, domain, enabled, created_at, updated_at)
+             VALUES ('next', 'asgi', 'next', 1, 0, 0)",
+            [],
+        )
+        .expect("insert after migration");
+        let next_id: i64 = conn
+            .query_row("SELECT id FROM apps WHERE name = 'next'", [], |r| r.get(0))
+            .expect("next id");
+        assert!(next_id > 7);
+    }
+
+    #[test]
     fn settings_crud() {
         let repo = AppRepository {
             conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
             domain_suffix: "coulson.local".to_string(),
             change_tx: None,
         };
@@ -1412,6 +2187,7 @@ mod tests {
     fn db_stores_prefix_only() {
         let repo = AppRepository {
             conn: Mutex::new(Connection::open_in_memory().expect("open sqlite")),
+            read_conn: None,
             domain_suffix: "coulson.local".to_string(),
             change_tx: None,
         };


### PR DESCRIPTION
## Summary

- App ids are now `AUTOINCREMENT` (never reused), and every spawn revalidates the store row under the PM lock, so a deleted app can no longer be resurrected by an in-flight request or confused with its replacement.
- All scan store mutations commit as one `BEGIN IMMEDIATE` transaction (`StoreTxn`), with in-transaction fs revalidation; explicit delete removes the row and its apps_root entry in the same transaction. The DB runs in WAL mode with a dedicated read connection so reads never queue behind a scan.
- Per-app hooks moved from an in-memory registry to a JSON column on the app row; every lifecycle event is built from a snapshot its emitter owns (deleted row, pruned row, or the process group's spawn-time snapshot), so events keep full context and hooks even after the row is gone.
- Provider detection is now tri-state (`Result<Option<DetectedApp>>`): fs/parse uncertainty (e.g. a mid-rewrite `package.json`) protects existing rows instead of pruning or reclassifying a live app, and a spawn-commit guard closes the validate-then-insert race against out-of-process scans.
- Fixes two pre-existing bugs surfaced along the way: the v1 schema migration silently dropped every later-added column, and `app.list`/`app.get` leaked hook commands, basic-auth passwords, and tunnel credentials (secrets now serialize as `*_set` presence booleans).

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` (258 tests; ~20 new covering txn rollback, migrations, prune protection, hooks round-trip, secret redaction, spawn-commit serialization).
- Live smoke on an isolated daemon: delete/prune/idle-reap event ordering with per-app hooks; offline `coulson scan` running against the same database as the daemon; orphan reap after an out-of-process prune fires a complete `app_stop` from the group snapshot.