### PR TITLE
feat(env): report app vs coulson scope for resolved variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ provider defaults  <  .coulson.toml [env]  <  env_url  <  .coulsonrc
 
 Rationale: committed `[env]` provides defaults/placeholders; `env_url` delivers authoritative remote secrets that override those defaults; `.coulsonrc` is the hand-edited local override that wins over everything (handy for pointing at a local DB while debugging). Below the provider defaults sit the user login-shell rc and the daemon's own environment.
 
+`coulson env` reports the winning effective value from these layers together with its source and scope. `app` settings are injected into managed app processes; `coulson` settings such as `COULSON_MANAGED_SERVICES` are consumed by Coulson itself and are not injected into those processes. Companion selection happens before `env_url` is fetched, so `COULSON_MANAGED_SERVICES` is only supported in `.coulson.toml [env]` and `.coulsonrc`; an `env_url` value is ignored. `--bare` prints both scopes as `KEY=value` lines.
+
 ### `.coulson.toml` — Per-App Configuration
 
 For full control, add a `.coulson.toml` in the app directory:
@@ -391,7 +393,7 @@ Priority: defaults < config file < environment variables.
 | `coulson start\|stop\|restart [name]` | Start / stop / restart a managed process |
 | `coulson ps` | Show running managed processes |
 | `coulson logs [name] [-f] [-n <lines>] [--path]` | Show logs (`--path` prints the log file path) |
-| `coulson env [name] [--bare\|--json] [--preview] [--no-remote]` | Show the resolved environment a process would receive |
+| `coulson env [name] [--bare\|--json] [--preview] [--no-remote]` | Show effective app and Coulson environment configuration with source and scope |
 | `coulson open [name]` | Open the app URL in the default browser |
 | `coulson attach [name]` | Attach to the process's tmux session |
 

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -39,7 +39,7 @@ use tabled::Tabled;
 use crate::config::{CoulsonConfig, LOCALHOST_SUFFIX};
 use crate::domain::{AppSpec, BackendTarget, TunnelMode};
 use crate::hooks::{HookContextFactory, HookManager};
-use crate::process::{ProcessManagerHandle, ProviderRegistry};
+use crate::process::{EnvScope, ProcessManagerHandle, ProviderRegistry};
 use crate::rpc_client::RpcClient;
 use crate::share::ShareSigner;
 use crate::store::AppRepository;
@@ -340,14 +340,14 @@ enum Commands {
         #[arg(long)]
         path: bool,
     },
-    /// Show the resolved environment a managed app's web process would receive
+    /// Show the resolved environment configuration for a managed app
     Env {
         /// App name or domain (omit to match CWD)
         name: Option<String>,
-        /// Print as plain KEY=value lines (no source column)
+        /// Print as plain KEY=value lines (no source or scope columns)
         #[arg(long)]
         bare: bool,
-        /// Print as JSON (array of {key, value, source})
+        /// Print as JSON (array of {key, value, source, scope})
         #[arg(long)]
         json: bool,
         /// Show the would-be env (re-resolved now) instead of the running process
@@ -2180,9 +2180,16 @@ async fn run_env(
     preview: bool,
     no_remote: bool,
 ) -> anyhow::Result<()> {
-    // Each row is (key, value, source_kind, source_label).
-    let rows: Vec<(String, String, String, String)> = if preview {
-        // Re-resolve locally: what the app *would* get if started now.
+    struct EnvRow {
+        key: String,
+        value: String,
+        source_kind: String,
+        source_label: String,
+        scope: EnvScope,
+    }
+
+    let rows: Vec<EnvRow> = if preview {
+        // Re-resolve locally: the effective config if the app started now.
         let bare_name = resolve_app_name(&cfg, name.as_deref())?;
         let domain_match = format!("{bare_name}.{}", cfg.domain_suffix);
         let state = build_state(&cfg)?;
@@ -2221,14 +2228,16 @@ async fn run_env(
         );
         entries
             .into_iter()
-            .map(|e| {
-                let kind = e.source.kind().to_string();
-                let label = e.source.label();
-                (e.key, e.value, kind, label)
+            .map(|e| EnvRow {
+                key: e.key,
+                value: e.value,
+                source_kind: e.source.kind().to_string(),
+                source_label: e.source.label(),
+                scope: e.scope,
             })
             .collect()
     } else {
-        // Live: the env the running process was actually started with.
+        // Live: the effective config captured when the app was started.
         let client = RpcClient::new(&cfg.control_socket);
         let (_bare_name, app_id) = resolve_app_id(&client, &cfg, name)?;
         let result = client.call("process.env", serde_json::json!({ "app_id": app_id }))?;
@@ -2243,7 +2252,20 @@ async fn run_env(
                         let source = e.get("source")?;
                         let kind = source.get("kind")?.as_str()?.to_string();
                         let label = source.get("label")?.as_str()?.to_string();
-                        Some((key, value, kind, label))
+                        // A daemon from before scope was introduced omitted the
+                        // field; those entries were all app-scoped. Present but
+                        // unknown values are rejected by the enum parser.
+                        let scope = match e.get("scope") {
+                            Some(value) => serde_json::from_value(value.clone()).ok()?,
+                            None => EnvScope::App,
+                        };
+                        Some(EnvRow {
+                            key,
+                            value,
+                            source_kind: kind,
+                            source_label: label,
+                            scope,
+                        })
                     })
                     .collect()
             })
@@ -2253,11 +2275,12 @@ async fn run_env(
     if json {
         let arr: Vec<serde_json::Value> = rows
             .iter()
-            .map(|(k, v, kind, label)| {
+            .map(|row| {
                 serde_json::json!({
-                    "key": k,
-                    "value": v,
-                    "source": { "kind": kind, "label": label },
+                    "key": row.key,
+                    "value": row.value,
+                    "source": { "kind": row.source_kind, "label": row.source_label },
+                    "scope": row.scope,
                 })
             })
             .collect();
@@ -2265,8 +2288,8 @@ async fn run_env(
         return Ok(());
     }
     if bare {
-        for (k, v, _, _) in &rows {
-            println!("{k}={v}");
+        for row in &rows {
+            println!("{}={}", row.key, row.value);
         }
         return Ok(());
     }
@@ -2274,51 +2297,69 @@ async fn run_env(
         return Ok(());
     }
 
-    // Aligned KEY + SOURCE columns (bounded widths); VALUE last. Long values
-    // are truncated to the terminal width so rows stay one line and aligned.
-    // When output is not a TTY (piped), values are shown in full.
+    // Aligned KEY + SCOPE + SOURCE columns (bounded widths); VALUE last. Long
+    // values are truncated to the terminal width so rows stay one line and
+    // aligned. When output is not a TTY (piped), values are shown in full.
     let key_w = rows
         .iter()
-        .map(|(k, ..)| k.chars().count())
+        .map(|row| row.key.chars().count())
         .max()
         .unwrap_or(0)
         .max("KEY".len());
     let src_w = rows
         .iter()
-        .map(|(_, _, _, label)| label.chars().count())
+        .map(|row| row.source_label.chars().count())
         .max()
         .unwrap_or(0)
         .max("SOURCE".len());
+    let scope_w = rows
+        .iter()
+        .map(|row| row.scope.label().chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("SCOPE".len());
 
     const SEP: usize = 2; // spaces between columns
     let value_budget = terminal_size::terminal_size().map(|(w, _)| {
         (w.0 as usize)
-            .saturating_sub(key_w + src_w + SEP * 2)
+            .saturating_sub(key_w + src_w + scope_w + SEP * 3)
             .max(8)
     });
 
     println!(
-        "{}  {}  {}",
+        "{}  {}  {}  {}",
         format!("{:<key_w$}", "KEY").dimmed(),
+        format!("{:<scope_w$}", "SCOPE").dimmed(),
         format!("{:<src_w$}", "SOURCE").dimmed(),
         "VALUE".dimmed()
     );
-    for (k, v, kind, label) in &rows {
-        let src_cell = format!("{label:<src_w$}");
-        let src_cell = match kind.as_str() {
+    for row in &rows {
+        let src_cell = format!("{:<src_w$}", row.source_label);
+        let src_cell = match row.source_kind.as_str() {
             "dotenv" => src_cell.green(),
             "env_url" => src_cell.cyan(),
             "toml" => src_cell.yellow(),
             _ => src_cell.dimmed(),
         };
+        let scope_cell = format!("{:<scope_w$}", row.scope.label());
+        let scope_cell = match row.scope {
+            EnvScope::Coulson => scope_cell.blue(),
+            EnvScope::App => scope_cell.dimmed(),
+        };
         let value = match value_budget {
-            Some(budget) if v.chars().count() > budget => {
-                let head: String = v.chars().take(budget.saturating_sub(1)).collect();
+            Some(budget) if row.value.chars().count() > budget => {
+                let head: String = row.value.chars().take(budget.saturating_sub(1)).collect();
                 format!("{head}…")
             }
-            _ => v.clone(),
+            _ => row.value.clone(),
         };
-        println!("{}  {}  {}", format!("{k:<key_w$}").bold(), src_cell, value);
+        println!(
+            "{}  {}  {}  {}",
+            format!("{:<key_w$}", row.key).bold(),
+            scope_cell,
+            src_cell,
+            value
+        );
     }
     Ok(())
 }

--- a/crates/coulson/src/process/mod.rs
+++ b/crates/coulson/src/process/mod.rs
@@ -209,17 +209,6 @@ impl EnvSource {
                 .unwrap_or_else(|| path.to_string_lossy().into_owned()),
         }
     }
-
-    /// Precedence rank (low → high). Used to order resolved entries so the
-    /// highest-priority overrides sort last.
-    fn rank(&self) -> u8 {
-        match self {
-            EnvSource::Provider => 0,
-            EnvSource::TomlEnv => 1,
-            EnvSource::EnvUrl => 2,
-            EnvSource::Dotenv(_) => 3,
-        }
-    }
 }
 
 impl serde::Serialize for EnvSource {
@@ -239,6 +228,33 @@ pub struct EnvEntry {
     pub key: String,
     pub value: String,
     pub source: EnvSource,
+    pub scope: EnvScope,
+}
+
+/// Where a resolved environment setting takes effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EnvScope {
+    /// Injected into the managed app's processes.
+    App,
+    /// Consumed by Coulson itself and not injected into app processes.
+    Coulson,
+}
+
+impl EnvScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::App => "app",
+            Self::Coulson => "coulson",
+        }
+    }
+
+    fn for_key(key: &str) -> Self {
+        match key {
+            "COULSON_MANAGED_SERVICES" => Self::Coulson,
+            _ => Self::App,
+        }
+    }
 }
 
 /// An ordered stack of named environment layers, lowest precedence first. Both
@@ -279,9 +295,7 @@ impl LayeredEnv {
         out
     }
 
-    /// Every key with its winning value and the layer that set it, ordered by
-    /// source precedence (low → high) then key — so the highest-priority
-    /// overrides (`.coulsonrc`) sort last.
+    /// Every key with its winning value and the layer that set it, ordered by key.
     fn resolve(&self) -> Vec<EnvEntry> {
         let mut map: std::collections::BTreeMap<String, (String, EnvSource)> =
             std::collections::BTreeMap::new();
@@ -290,14 +304,14 @@ impl LayeredEnv {
                 map.insert(k.clone(), (v.clone(), src.clone()));
             }
         }
-        // BTreeMap gives key order; stable-sort by rank preserves key order
-        // within each precedence tier.
-        let mut entries: Vec<EnvEntry> = map
-            .into_iter()
-            .map(|(key, (value, source))| EnvEntry { key, value, source })
-            .collect();
-        entries.sort_by_key(|e| e.source.rank());
-        entries
+        map.into_iter()
+            .map(|(key, (value, source))| EnvEntry {
+                scope: EnvScope::for_key(&key),
+                key,
+                value,
+                source,
+            })
+            .collect()
     }
 }
 
@@ -373,10 +387,10 @@ impl ProcessManager {
         types
     }
 
-    /// The resolved environment (with provenance) the running web process was
-    /// started with. `None` if no process is tracked for this app, or the
-    /// tracked process has already exited (so callers report "not running"
-    /// instead of stale env for a dead handle).
+    /// The resolved environment configuration (with provenance and scope)
+    /// captured when the running app was started. `None` if no process is
+    /// tracked for this app, or the tracked process has already exited (so
+    /// callers report "not running" instead of stale env for a dead handle).
     pub fn process_env(&mut self, app_id: i64) -> Option<&[EnvEntry]> {
         let group = self.processes.get_mut(&app_id)?;
         if !is_alive(&mut group.primary.handle) {
@@ -1198,8 +1212,9 @@ impl ProcessManager {
 
         // Provider seeds `spec.env` with its framework defaults only. The
         // authoritative env layering (`.coulson.toml [env]` < env_url <
-        // `.coulsonrc`) and the `COULSON_MANAGED_SERVICES` strip are applied
-        // later by `apply_and_capture_env`, once env_url has been fetched.
+        // `.coulsonrc`) is applied later by `apply_and_capture_env`, once
+        // env_url has been fetched. Coulson-only settings are captured for
+        // inspection but stripped from the child environment there.
         let spec = prov.resolve(&managed_app)?;
 
         let _ = app_id; // used in caller for logging
@@ -1213,14 +1228,17 @@ impl ProcessManager {
         ))
     }
 
-    /// Resolve the environment a managed app's **web** process would receive,
-    /// annotating each variable with the source that won it — WITHOUT spawning.
+    /// Resolve a managed app's effective environment configuration, annotating
+    /// each variable with the source that won it and where it takes effect —
+    /// WITHOUT spawning.
     ///
-    /// Reuses the real spawn path (`resolve_spec` + `finalize_managed_env`) so
-    /// the result matches what the child would actually get. Resolving the
-    /// provider spec has the same side effects as a real start (binary
-    /// detection, and a transient free-port probe for TCP providers). When
-    /// `fetch_remote` is true, `env_url` is fetched. Used by `coulson env`.
+    /// Reuses the real spawn path (`resolve_spec` + `build_layered_env`) so
+    /// App-scoped entries match what the child would actually get. Coulson-
+    /// scoped entries are effective settings consumed by Coulson itself and
+    /// deliberately omitted from the child environment. Resolving the provider
+    /// spec has the same side effects as a real start (binary detection, and a
+    /// transient free-port probe for TCP providers). When `fetch_remote` is
+    /// true, `env_url` is fetched. Used by `coulson env`.
     pub async fn inspect_env(
         &self,
         app_id: i64,
@@ -1241,9 +1259,7 @@ impl ProcessManager {
         // Provenance falls straight out of the layered fold — no reverse lookup.
         let layered =
             build_layered_env(spec.env, &manifest, env_url_env.as_ref(), &coulsonrc, root);
-        let mut entries = layered.resolve();
-        entries.retain(|e| e.key != "COULSON_MANAGED_SERVICES");
-        Ok(entries)
+        Ok(layered.resolve())
     }
 
     /// Spawn a process using the current backend (direct or tmux).
@@ -1722,6 +1738,11 @@ fn manifest_env_map(manifest: Option<&serde_json::Value>) -> HashMap<String, Str
 /// in those layers would desync the child's `$PORT` from `listen_target` and
 /// break routing. It is therefore stripped from those overlay layers; the
 /// provider-chosen value (echoed by `.coulsonrc` when set there) stands.
+///
+/// `COULSON_MANAGED_SERVICES` is another control setting: companion selection
+/// happens before `env_url` is fetched, so only `.coulson.toml [env]` and
+/// `.coulsonrc` are supported sources. An env_url value is ignored rather than
+/// reported as if it had affected the startup decision.
 fn build_layered_env(
     provider_defaults: HashMap<String, String>,
     manifest: &Option<serde_json::Value>,
@@ -1743,6 +1764,11 @@ fn build_layered_env(
         if remote.remove("PORT").is_some() {
             debug!("ignoring PORT from env_url; PORT is managed by the provider");
         }
+        if remote.remove("COULSON_MANAGED_SERVICES").is_some() {
+            debug!(
+                "ignoring COULSON_MANAGED_SERVICES from env_url; it is only supported in .coulson.toml and .coulsonrc"
+            );
+        }
         env.push(EnvSource::EnvUrl, remote);
     }
 
@@ -1753,10 +1779,10 @@ fn build_layered_env(
     env
 }
 
-/// Apply the layered environment onto `spec.env` (merged, with the
-/// `COULSON_MANAGED_SERVICES` meta-var stripped) and return the resolved entries
-/// (with provenance, meta-var stripped) for storage / inspection. The meta-var
-/// selects companion processes and must never reach the child environment.
+/// Apply the app-scoped layered environment onto `spec.env` and return all
+/// effective entries (including Coulson-scoped settings) for inspection. The
+/// `COULSON_MANAGED_SERVICES` meta-var selects companion processes, so it is
+/// reported with `scope=coulson` but must never reach the child environment.
 fn apply_and_capture_env(
     spec: &mut ProcessSpec,
     manifest: &Option<serde_json::Value>,
@@ -1775,9 +1801,7 @@ fn apply_and_capture_env(
     merged.remove("COULSON_MANAGED_SERVICES");
     spec.env = merged;
 
-    let mut entries = layered.resolve();
-    entries.retain(|e| e.key != "COULSON_MANAGED_SERVICES");
-    entries
+    layered.resolve()
 }
 
 /// Parse environment variables from a response body.
@@ -3118,7 +3142,7 @@ mod tests {
     }
 
     #[test]
-    fn finalize_managed_env_precedence_and_strips_managed_services() {
+    fn apply_and_capture_env_reports_managed_services_but_strips_it_from_child() {
         use crate::process::provider::ListenTarget;
         let dir =
             std::env::temp_dir().join(format!("coulson-test-finalize-env-{}", std::process::id()));
@@ -3176,27 +3200,39 @@ mod tests {
         // The managed-services meta-var must never leak into the child env.
         assert!(!spec.env.contains_key("COULSON_MANAGED_SERVICES"));
 
-        // --- captured provenance: winning source per key, meta-var excluded ---
+        // --- captured inspection: winning source and scope per effective key ---
         let kind = |k: &str| entries.iter().find(|e| e.key == k).map(|e| e.source.kind());
+        let scope = |k: &str| entries.iter().find(|e| e.key == k).map(|e| e.scope);
         assert_eq!(kind("RC_WINS"), Some("dotenv"));
         assert_eq!(kind("URL_WINS"), Some("env_url"));
         assert_eq!(kind("ONLY_TOML"), Some("toml"));
         assert_eq!(kind("ONLY_PROVIDER"), Some("provider"));
-        assert!(kind("COULSON_MANAGED_SERVICES").is_none());
+        assert_eq!(kind("COULSON_MANAGED_SERVICES"), Some("dotenv"));
+        assert_eq!(scope("COULSON_MANAGED_SERVICES"), Some(EnvScope::Coulson));
+        assert_eq!(scope("ONLY_RC"), Some(EnvScope::App));
+        let managed_services = entries
+            .iter()
+            .find(|e| e.key == "COULSON_MANAGED_SERVICES")
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(managed_services).unwrap()["scope"],
+            "coulson"
+        );
         // The dotenv source carries the concrete file.
         let rc = entries.iter().find(|e| e.key == "RC_WINS").unwrap();
         assert!(matches!(&rc.source, EnvSource::Dotenv(p) if p.ends_with(".coulsonrc")));
-        // Ordered by source precedence (low → high), key within tier.
+        // Ordered by key regardless of scope.
         let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
         assert_eq!(
             keys,
             vec![
+                "COULSON_MANAGED_SERVICES",
                 "ONLY_PROVIDER",
+                "ONLY_RC",
                 "ONLY_TOML",
                 "ONLY_URL",
-                "URL_WINS",
-                "ONLY_RC",
-                "RC_WINS"
+                "RC_WINS",
+                "URL_WINS"
             ]
         );
 
@@ -3243,10 +3279,9 @@ mod tests {
         assert_eq!(kind("B"), Some("env_url"));
         assert_eq!(kind("C"), Some("env_url"));
         assert_eq!(kind("PORT"), Some("provider"));
-        // Ordered by source precedence (low → high), key within tier:
-        // provider(PORT) < env_url(B,C) < dotenv(A,D).
+        // Entries sort by key.
         let keys: Vec<&str> = resolved.iter().map(|e| e.key.as_str()).collect();
-        assert_eq!(keys, vec!["PORT", "B", "C", "A", "D"]);
+        assert_eq!(keys, vec!["A", "B", "C", "D", "PORT"]);
     }
 
     #[test]
@@ -3269,6 +3304,48 @@ mod tests {
         assert_eq!(merged.get("PORT").map(String::as_str), Some("PROVIDER"));
         // Non-PORT overlay keys still apply.
         assert_eq!(merged.get("X").map(String::as_str), Some("x"));
+    }
+
+    #[test]
+    fn managed_services_is_ignored_from_env_url() {
+        // Companion selection happens before env_url is fetched, so inspection
+        // must report the same supported source that startup actually uses.
+        let manifest = Some(serde_json::json!({
+            "env": { "COULSON_MANAGED_SERVICES": "worker" }
+        }));
+        let url = HashMap::from([(
+            "COULSON_MANAGED_SERVICES".to_string(),
+            "scheduler".to_string(),
+        )]);
+        let layered = build_layered_env(
+            HashMap::new(),
+            &manifest,
+            Some(&url),
+            &HashMap::new(),
+            Path::new("/app"),
+        );
+
+        assert_eq!(layered.get("COULSON_MANAGED_SERVICES"), Some("worker"));
+        let entry = layered
+            .resolve()
+            .into_iter()
+            .find(|e| e.key == "COULSON_MANAGED_SERVICES")
+            .unwrap();
+        assert_eq!(entry.source.kind(), "toml");
+        assert_eq!(entry.scope, EnvScope::Coulson);
+    }
+
+    #[test]
+    fn env_scope_serde_uses_lowercase_names_and_rejects_unknown_values() {
+        assert_eq!(
+            serde_json::from_str::<EnvScope>(r#""app""#).unwrap(),
+            EnvScope::App
+        );
+        assert_eq!(
+            serde_json::from_str::<EnvScope>(r#""coulson""#).unwrap(),
+            EnvScope::Coulson
+        );
+        assert!(serde_json::from_str::<EnvScope>(r#""process""#).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `EnvScope` (`app` / `coulson`) to `EnvEntry`, tagging every resolved variable with where it takes effect
- `coulson env` gains a SCOPE column (and `scope` field in `--json`); entries now sort by key instead of source precedence
- `COULSON_MANAGED_SERVICES` is now reported as `scope=coulson` instead of being silently excluded from output

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (260 passed)