### PR TITLE
feat(tunnel): trusted x-forwarded-host allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,13 +364,13 @@ When a named tunnel sits behind an ingress worker that supplies the visitor's
 original `X-Forwarded-Host`, allow only the external hosts you control:
 
 ```toml
-tunnel_trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
+trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
 ```
 
 The default empty list ignores incoming `X-Forwarded-Host` values. Exact
 patterns match one host; `*.example.com` matches exactly one leading DNS label.
 The equivalent environment variable is
-`COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"`.
+`COULSON_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"`.
 
 This option is not intended for Quick Tunnels (`*.trycloudflare.com`), which
 have no fronting ingress worker.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,23 @@ Configure wildcard DNS for your own domain (e.g. `*.example.com`) pointing to a 
 
 All projects share one Tunnel connection — no per-app setup needed, new projects are instantly accessible from the public internet.
 
+### Trusted Forwarded Host
+
+When a named tunnel sits behind an ingress worker that supplies the visitor's
+original `X-Forwarded-Host`, allow only the external hosts you control:
+
+```toml
+tunnel_trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
+```
+
+The default empty list ignores incoming `X-Forwarded-Host` values. Exact
+patterns match one host; `*.example.com` matches exactly one leading DNS label.
+The equivalent environment variable is
+`COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"`.
+
+This option is not intended for Quick Tunnels (`*.trycloudflare.com`), which
+have no fronting ingress worker.
+
 ## Management
 
 - **Web Dashboard**: `http://coulson.local:18080`

--- a/config.example.toml
+++ b/config.example.toml
@@ -29,8 +29,8 @@
 # Trust an ingress worker's X-Forwarded-Host only for these external hosts.
 # Empty (default) disables the feature. Wildcards match exactly one DNS label.
 # Intended for named tunnels behind an ingress worker, not Quick Tunnels.
-# Env: COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"
-# tunnel_trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
+# Env: COULSON_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"
+# trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
 
 # TLS certificate directory
 # certs_dir = "~/.config/coulson/certs"

--- a/config.example.toml
+++ b/config.example.toml
@@ -26,6 +26,12 @@
 # Max requests to keep in the inspector buffer
 # inspect_max_requests = 200
 
+# Trust an ingress worker's X-Forwarded-Host only for these external hosts.
+# Empty (default) disables the feature. Wildcards match exactly one DNS label.
+# Intended for named tunnels behind an ingress worker, not Quick Tunnels.
+# Env: COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS="*.example.com,app.example.net"
+# tunnel_trusted_forwarded_hosts = ["*.example.com", "app.example.net"]
+
 # TLS certificate directory
 # certs_dir = "~/.config/coulson/certs"
 

--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -500,6 +500,62 @@ mod tests {
     }
 
     #[test]
+    fn load_applies_toml_hosts_and_env_override() {
+        const CHILD_MARKER: &str = "COULSON_CONFIG_LAYER_TEST_CHILD";
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let from_toml = CoulsonConfig::load().expect("load TOML config");
+            assert_eq!(
+                from_toml.tunnel_trusted_forwarded_hosts,
+                vec![
+                    "toml.example.com".to_string(),
+                    "*.toml.example.com".to_string()
+                ]
+            );
+
+            std::env::set_var(
+                "COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS",
+                " *.env.example.com, app.env.example.com ,, ",
+            );
+            let from_env = CoulsonConfig::load().expect("load env override");
+            assert_eq!(
+                from_env.tunnel_trusted_forwarded_hosts,
+                vec![
+                    "*.env.example.com".to_string(),
+                    "app.env.example.com".to_string()
+                ]
+            );
+            return;
+        }
+
+        let temp_root =
+            std::env::temp_dir().join(format!("coulson-config-layer-{}", std::process::id()));
+        let config_dir = temp_root.join(DIR_NAME);
+        std::fs::create_dir_all(&config_dir).expect("create config directory");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            r#"tunnel_trusted_forwarded_hosts = ["toml.example.com", "*.toml.example.com"]"#,
+        )
+        .expect("write config");
+
+        let status = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .args([
+                "--exact",
+                "config::tests::load_applies_toml_hosts_and_env_override",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env("HOME", &temp_root)
+            .env("XDG_CONFIG_HOME", &temp_root)
+            .env("XDG_STATE_HOME", &temp_root)
+            .env("XDG_RUNTIME_DIR", &temp_root)
+            .env_remove("COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS")
+            .status()
+            .expect("run isolated config test");
+
+        std::fs::remove_dir_all(&temp_root).expect("remove config directory");
+        assert!(status.success(), "isolated config test failed");
+    }
+
+    #[test]
     fn merge_keeps_base_when_dev_field_unset() {
         let mut base = ConfigFile {
             max_tunnel_body_mb: Some(100),

--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -80,6 +80,9 @@ pub struct CoulsonConfig {
     pub inspect_max_requests: usize,
     /// Max request body (MiB) buffered per tunnel request before returning 413.
     pub max_tunnel_body_mb: usize,
+    /// Host patterns (exact or `*.domain`) for which an incoming
+    /// x-forwarded-host on tunnel requests is trusted. Empty = off.
+    pub tunnel_trusted_forwarded_hosts: Vec<String>,
     pub certs_dir: PathBuf,
     pub runtime_dir: PathBuf,
     pub process_backend: ProcessBackend,
@@ -121,6 +124,7 @@ impl Default for CoulsonConfig {
             link_dir: false,
             inspect_max_requests: 200,
             max_tunnel_body_mb: 100,
+            tunnel_trusted_forwarded_hosts: Vec::new(),
             certs_dir: xdg_config_home().join(format!("{DIR_NAME}/certs")),
             runtime_dir,
             process_backend: ProcessBackend::Auto,
@@ -170,6 +174,9 @@ impl CoulsonConfig {
         }
         if let Some(v) = file.max_tunnel_body_mb {
             cfg.max_tunnel_body_mb = v;
+        }
+        if let Some(ref v) = file.tunnel_trusted_forwarded_hosts {
+            cfg.tunnel_trusted_forwarded_hosts = v.clone();
         }
         if let Some(ref v) = file.certs_dir {
             cfg.certs_dir = expand_tilde(v);
@@ -241,6 +248,10 @@ impl CoulsonConfig {
             cfg.max_tunnel_body_mb = raw
                 .parse()
                 .with_context(|| format!("invalid COULSON_MAX_TUNNEL_BODY_MB: {raw}"))?;
+        }
+
+        if let Ok(raw) = env::var("COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS") {
+            cfg.tunnel_trusted_forwarded_hosts = parse_host_list(&raw);
         }
 
         if let Ok(path) = env::var("COULSON_CERTS_DIR") {
@@ -317,6 +328,14 @@ fn parse_bool(input: &str) -> anyhow::Result<bool> {
     }
 }
 
+fn parse_host_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 /// Parse a listen address: bare port (`18080`) → `0.0.0.0:18080`,
 /// or a full `ip:port` string.
 fn parse_listen_addr(input: &str) -> anyhow::Result<SocketAddr> {
@@ -358,6 +377,7 @@ struct ConfigFile {
     link_dir: Option<bool>,
     inspect_max_requests: Option<usize>,
     max_tunnel_body_mb: Option<usize>,
+    tunnel_trusted_forwarded_hosts: Option<Vec<String>>,
     certs_dir: Option<String>,
     runtime_dir: Option<String>,
     process_backend: Option<String>,
@@ -422,6 +442,7 @@ impl ConfigFile {
             link_dir,
             inspect_max_requests,
             max_tunnel_body_mb,
+            tunnel_trusted_forwarded_hosts,
             certs_dir,
             runtime_dir,
             process_backend,
@@ -447,6 +468,35 @@ mod tests {
         };
         base.merge(dev);
         assert_eq!(base.max_tunnel_body_mb, Some(512));
+    }
+
+    #[test]
+    fn merge_overrides_tunnel_trusted_forwarded_hosts() {
+        let mut base = ConfigFile {
+            tunnel_trusted_forwarded_hosts: Some(vec!["a.example.com".to_string()]),
+            ..Default::default()
+        };
+        let dev = ConfigFile {
+            tunnel_trusted_forwarded_hosts: Some(vec!["*.example.com".to_string()]),
+            ..Default::default()
+        };
+        base.merge(dev);
+        assert_eq!(
+            base.tunnel_trusted_forwarded_hosts,
+            Some(vec!["*.example.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_host_list_splits_trims_and_drops_empties() {
+        assert_eq!(
+            parse_host_list(" *.example.org , app.example.com ,, "),
+            vec![
+                "*.example.org".to_string(),
+                "app.example.com".to_string()
+            ]
+        );
+        assert!(parse_host_list("").is_empty());
     }
 
     #[test]

--- a/crates/coulson/src/config.rs
+++ b/crates/coulson/src/config.rs
@@ -81,8 +81,9 @@ pub struct CoulsonConfig {
     /// Max request body (MiB) buffered per tunnel request before returning 413.
     pub max_tunnel_body_mb: usize,
     /// Host patterns (exact or `*.domain`) for which an incoming
-    /// x-forwarded-host on tunnel requests is trusted. Empty = off.
-    pub tunnel_trusted_forwarded_hosts: Vec<String>,
+    /// x-forwarded-host is trusted. Currently consulted only by the tunnel
+    /// ingress. Empty = off.
+    pub trusted_forwarded_hosts: Vec<String>,
     pub certs_dir: PathBuf,
     pub runtime_dir: PathBuf,
     pub process_backend: ProcessBackend,
@@ -124,7 +125,7 @@ impl Default for CoulsonConfig {
             link_dir: false,
             inspect_max_requests: 200,
             max_tunnel_body_mb: 100,
-            tunnel_trusted_forwarded_hosts: Vec::new(),
+            trusted_forwarded_hosts: Vec::new(),
             certs_dir: xdg_config_home().join(format!("{DIR_NAME}/certs")),
             runtime_dir,
             process_backend: ProcessBackend::Auto,
@@ -175,8 +176,8 @@ impl CoulsonConfig {
         if let Some(v) = file.max_tunnel_body_mb {
             cfg.max_tunnel_body_mb = v;
         }
-        if let Some(ref v) = file.tunnel_trusted_forwarded_hosts {
-            cfg.tunnel_trusted_forwarded_hosts = v.clone();
+        if let Some(ref v) = file.trusted_forwarded_hosts {
+            cfg.trusted_forwarded_hosts = v.clone();
         }
         if let Some(ref v) = file.certs_dir {
             cfg.certs_dir = expand_tilde(v);
@@ -250,8 +251,8 @@ impl CoulsonConfig {
                 .with_context(|| format!("invalid COULSON_MAX_TUNNEL_BODY_MB: {raw}"))?;
         }
 
-        if let Ok(raw) = env::var("COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS") {
-            cfg.tunnel_trusted_forwarded_hosts = parse_host_list(&raw);
+        if let Ok(raw) = env::var("COULSON_TRUSTED_FORWARDED_HOSTS") {
+            cfg.trusted_forwarded_hosts = parse_host_list(&raw);
         }
 
         if let Ok(path) = env::var("COULSON_CERTS_DIR") {
@@ -377,7 +378,7 @@ struct ConfigFile {
     link_dir: Option<bool>,
     inspect_max_requests: Option<usize>,
     max_tunnel_body_mb: Option<usize>,
-    tunnel_trusted_forwarded_hosts: Option<Vec<String>>,
+    trusted_forwarded_hosts: Option<Vec<String>>,
     certs_dir: Option<String>,
     runtime_dir: Option<String>,
     process_backend: Option<String>,
@@ -442,7 +443,7 @@ impl ConfigFile {
             link_dir,
             inspect_max_requests,
             max_tunnel_body_mb,
-            tunnel_trusted_forwarded_hosts,
+            trusted_forwarded_hosts,
             certs_dir,
             runtime_dir,
             process_backend,
@@ -471,18 +472,18 @@ mod tests {
     }
 
     #[test]
-    fn merge_overrides_tunnel_trusted_forwarded_hosts() {
+    fn merge_overrides_trusted_forwarded_hosts() {
         let mut base = ConfigFile {
-            tunnel_trusted_forwarded_hosts: Some(vec!["a.example.com".to_string()]),
+            trusted_forwarded_hosts: Some(vec!["a.example.com".to_string()]),
             ..Default::default()
         };
         let dev = ConfigFile {
-            tunnel_trusted_forwarded_hosts: Some(vec!["*.example.com".to_string()]),
+            trusted_forwarded_hosts: Some(vec!["*.example.com".to_string()]),
             ..Default::default()
         };
         base.merge(dev);
         assert_eq!(
-            base.tunnel_trusted_forwarded_hosts,
+            base.trusted_forwarded_hosts,
             Some(vec!["*.example.com".to_string()])
         );
     }
@@ -491,10 +492,7 @@ mod tests {
     fn parse_host_list_splits_trims_and_drops_empties() {
         assert_eq!(
             parse_host_list(" *.example.org , app.example.com ,, "),
-            vec![
-                "*.example.org".to_string(),
-                "app.example.com".to_string()
-            ]
+            vec!["*.example.org".to_string(), "app.example.com".to_string()]
         );
         assert!(parse_host_list("").is_empty());
     }
@@ -505,7 +503,7 @@ mod tests {
         if std::env::var_os(CHILD_MARKER).is_some() {
             let from_toml = CoulsonConfig::load().expect("load TOML config");
             assert_eq!(
-                from_toml.tunnel_trusted_forwarded_hosts,
+                from_toml.trusted_forwarded_hosts,
                 vec![
                     "toml.example.com".to_string(),
                     "*.toml.example.com".to_string()
@@ -513,12 +511,12 @@ mod tests {
             );
 
             std::env::set_var(
-                "COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS",
+                "COULSON_TRUSTED_FORWARDED_HOSTS",
                 " *.env.example.com, app.env.example.com ,, ",
             );
             let from_env = CoulsonConfig::load().expect("load env override");
             assert_eq!(
-                from_env.tunnel_trusted_forwarded_hosts,
+                from_env.trusted_forwarded_hosts,
                 vec![
                     "*.env.example.com".to_string(),
                     "app.env.example.com".to_string()
@@ -533,7 +531,7 @@ mod tests {
         std::fs::create_dir_all(&config_dir).expect("create config directory");
         std::fs::write(
             config_dir.join("config.toml"),
-            r#"tunnel_trusted_forwarded_hosts = ["toml.example.com", "*.toml.example.com"]"#,
+            r#"trusted_forwarded_hosts = ["toml.example.com", "*.toml.example.com"]"#,
         )
         .expect("write config");
 
@@ -547,7 +545,7 @@ mod tests {
             .env("XDG_CONFIG_HOME", &temp_root)
             .env("XDG_STATE_HOME", &temp_root)
             .env("XDG_RUNTIME_DIR", &temp_root)
-            .env_remove("COULSON_TUNNEL_TRUSTED_FORWARDED_HOSTS")
+            .env_remove("COULSON_TRUSTED_FORWARDED_HOSTS")
             .status()
             .expect("run isolated config test");
 

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1059,6 +1059,7 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
     // Saturate rather than wrap/panic on an absurd config value (a wrap could
     // silently shrink the cap instead of enlarging it).
     tunnel::proxy::set_max_tunnel_request_body(cfg.max_tunnel_body_mb.saturating_mul(1024 * 1024));
+    tunnel::proxy::set_trusted_forwarded_hosts(cfg.tunnel_trusted_forwarded_hosts.clone());
 
     let state = build_state(&cfg)?;
 

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -1059,7 +1059,7 @@ async fn run_serve(cfg: CoulsonConfig) -> anyhow::Result<()> {
     // Saturate rather than wrap/panic on an absurd config value (a wrap could
     // silently shrink the cap instead of enlarging it).
     tunnel::proxy::set_max_tunnel_request_body(cfg.max_tunnel_body_mb.saturating_mul(1024 * 1024));
-    tunnel::proxy::set_trusted_forwarded_hosts(cfg.tunnel_trusted_forwarded_hosts.clone());
+    tunnel::proxy::set_trusted_forwarded_hosts(cfg.trusted_forwarded_hosts.clone());
 
     let state = build_state(&cfg)?;
 

--- a/crates/coulson/src/tunnel/proxy.rs
+++ b/crates/coulson/src/tunnel/proxy.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use bytes::Bytes;
 use h2::RecvStream;
@@ -35,6 +35,37 @@ static MAX_TUNNEL_REQUEST_BODY: AtomicUsize = AtomicUsize::new(100 * 1024 * 1024
 /// from the loaded `CoulsonConfig`.
 pub fn set_max_tunnel_request_body(bytes: usize) {
     MAX_TUNNEL_REQUEST_BODY.store(bytes, Ordering::Relaxed);
+}
+
+/// Host patterns for which an incoming `x-forwarded-host` value is trusted.
+/// Empty (the default) disables the feature. Set once at daemon startup via
+/// [`set_trusted_forwarded_hosts`].
+static TRUSTED_FORWARDED_HOSTS: RwLock<Vec<String>> = RwLock::new(Vec::new());
+
+pub fn set_trusted_forwarded_hosts(patterns: Vec<String>) {
+    *TRUSTED_FORWARDED_HOSTS
+        .write()
+        .expect("trusted forwarded hosts lock poisoned") = patterns;
+}
+
+/// True if `host` (port stripped, case-insensitive) matches any pattern.
+/// `*.example.com` matches exactly one leading DNS label.
+fn host_matches(host: &str, patterns: &[String]) -> bool {
+    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    if host.is_empty() {
+        return false;
+    }
+    patterns.iter().any(|pattern| {
+        let pattern = pattern.to_ascii_lowercase();
+        if let Some(suffix) = pattern.strip_prefix("*.") {
+            match host.split_once('.') {
+                Some((label, rest)) => !label.is_empty() && rest == suffix,
+                None => false,
+            }
+        } else {
+            host == pattern
+        }
+    })
 }
 
 /// Read the full h2 request body into memory, enforcing the configured
@@ -361,8 +392,24 @@ fn append_forwarding_headers(
     original_host: &str,
     incoming_headers: &http::HeaderMap,
 ) {
+    // Trust the incoming x-forwarded-host only when it matches the configured
+    // allowlist; the tunnel domain is publicly reachable, so anything else is
+    // client-forgeable.
+    let forwarded_host = incoming_headers
+        .get("x-forwarded-host")
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.is_empty())
+        .filter(|v| {
+            let patterns = TRUSTED_FORWARDED_HOSTS
+                .read()
+                .expect("trusted forwarded hosts lock poisoned");
+            host_matches(v, &patterns)
+        })
+        .unwrap_or(original_host)
+        .to_string();
+
     *builder = std::mem::take(builder)
-        .header("x-forwarded-host", original_host)
+        .header("x-forwarded-host", forwarded_host)
         .header("x-forwarded-proto", "https");
 
     // Propagate client IP from Cloudflare headers
@@ -482,5 +529,94 @@ mod tests {
             map_tunnel_host_to_local("unknown.other.com", "dev.example.com", "test"),
             "default.test"
         );
+    }
+
+    #[test]
+    fn test_host_matches() {
+        let patterns = vec![
+            "app.example.com".to_string(),
+            "*.example.org".to_string(),
+        ];
+
+        // exact
+        assert!(host_matches("app.example.com", &patterns));
+        assert!(!host_matches("other.example.com", &patterns));
+
+        // wildcard: exactly one label
+        assert!(host_matches("app-sandbox2.example.org", &patterns));
+        assert!(!host_matches("a.b.example.org", &patterns));
+        assert!(!host_matches("example.org", &patterns));
+        // suffix must match whole labels, not substrings
+        assert!(!host_matches("app.evil-example.org", &patterns));
+
+        // case-insensitive, port stripped
+        assert!(host_matches("APP.Example.COM", &patterns));
+        assert!(host_matches("app.example.com:8443", &patterns));
+        assert!(host_matches("x.EXAMPLE.ORG", &patterns));
+
+        // empties
+        assert!(!host_matches("", &patterns));
+        assert!(!host_matches("app.example.com", &[]));
+    }
+
+    #[test]
+    fn test_append_forwarding_headers_trust_allowlist() {
+        fn built_forwarded_host(original_host: &str, incoming: &http::HeaderMap) -> String {
+            let mut builder = http::Request::builder().uri("http://127.0.0.1/");
+            append_forwarding_headers(&mut builder, original_host, incoming);
+            builder
+                .headers_ref()
+                .unwrap()
+                .get("x-forwarded-host")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        }
+
+        let mut incoming = http::HeaderMap::new();
+        incoming.insert("x-forwarded-host", "app.example.org".parse().unwrap());
+
+        // default (empty allowlist): incoming value ignored
+        set_trusted_forwarded_hosts(Vec::new());
+        assert_eq!(
+            built_forwarded_host("tunnel.example.net", &incoming),
+            "tunnel.example.net"
+        );
+
+        // allowlist hit: incoming value wins
+        set_trusted_forwarded_hosts(vec!["*.example.org".to_string()]);
+        assert_eq!(
+            built_forwarded_host("tunnel.example.net", &incoming),
+            "app.example.org"
+        );
+
+        // allowlist miss: fall back to original_host
+        let mut spoofed = http::HeaderMap::new();
+        spoofed.insert("x-forwarded-host", "evil.com".parse().unwrap());
+        assert_eq!(
+            built_forwarded_host("tunnel.example.net", &spoofed),
+            "tunnel.example.net"
+        );
+
+        // header absent: fall back
+        assert_eq!(
+            built_forwarded_host("tunnel.example.net", &http::HeaderMap::new()),
+            "tunnel.example.net"
+        );
+
+        // x-forwarded-proto untouched in all cases
+        let mut builder = http::Request::builder().uri("http://127.0.0.1/");
+        append_forwarding_headers(&mut builder, "tunnel.example.net", &incoming);
+        assert_eq!(
+            builder
+                .headers_ref()
+                .unwrap()
+                .get("x-forwarded-proto")
+                .unwrap(),
+            "https"
+        );
+
+        set_trusted_forwarded_hosts(Vec::new());
     }
 }

--- a/crates/coulson/src/tunnel/proxy.rs
+++ b/crates/coulson/src/tunnel/proxy.rs
@@ -51,7 +51,10 @@ pub fn set_trusted_forwarded_hosts(patterns: Vec<String>) {
 /// True if `host` (port stripped, case-insensitive) matches any pattern.
 /// `*.example.com` matches exactly one leading DNS label.
 fn host_matches(host: &str, patterns: &[String]) -> bool {
-    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    let Ok(authority) = host.parse::<http::uri::Authority>() else {
+        return false;
+    };
+    let host = authority.host().to_ascii_lowercase();
     if host.is_empty() {
         return false;
     }
@@ -596,6 +599,19 @@ mod tests {
         spoofed.insert("x-forwarded-host", "evil.com".parse().unwrap());
         assert_eq!(
             built_forwarded_host("tunnel.example.net", &spoofed),
+            "tunnel.example.net"
+        );
+
+        // A colon suffix must be a real numeric port, not arbitrary authority
+        // syntax that could be interpreted as a different host downstream.
+        set_trusted_forwarded_hosts(vec!["app.example.com".to_string()]);
+        let mut malformed = http::HeaderMap::new();
+        malformed.insert(
+            "x-forwarded-host",
+            "app.example.com:@evil.com".parse().unwrap(),
+        );
+        assert_eq!(
+            built_forwarded_host("tunnel.example.net", &malformed),
             "tunnel.example.net"
         );
 

--- a/crates/coulson/src/tunnel/proxy.rs
+++ b/crates/coulson/src/tunnel/proxy.rs
@@ -536,10 +536,7 @@ mod tests {
 
     #[test]
     fn test_host_matches() {
-        let patterns = vec![
-            "app.example.com".to_string(),
-            "*.example.org".to_string(),
-        ];
+        let patterns = vec!["app.example.com".to_string(), "*.example.org".to_string()];
 
         // exact
         assert!(host_matches("app.example.com", &patterns));


### PR DESCRIPTION
## Summary
- Honor an incoming `x-forwarded-host` on tunnel requests only when it matches a configured allowlist, so backends behind a fronting ingress worker see the real visitor host instead of the tunnel domain
- New config `trusted_forwarded_hosts` (TOML array / `COULSON_TRUSTED_FORWARDED_HOSTS` comma-separated env), default empty = off; wildcard `*.domain` matches exactly one DNS label
- Default stays off because Cloudflare passes `x-forwarded-host` through verbatim from the client (unlike `x-forwarded-for`/`-proto`), so anyone hitting the tunnel domain directly could spoof it; the allowlist bounds spoofing to the operator's own declared hosts
- Incoming forwarding headers are still unconditionally stripped; only the value migrates via `append_forwarding_headers`, and `x-forwarded-proto` stays hardcoded `https`

## Test plan
- Unit tests for the matcher (exact/wildcard/case/port/IPv6 authority parsing), `append_forwarding_headers` hit/miss/fallback, and config TOML+env layering
- `mise run lint` and `mise run test` (265 tests) clean