### PR TITLE
fix(macos): attribute background items to Coulson

### DIFF
--- a/CoulsonApp/Sources/Services/DaemonManager.swift
+++ b/CoulsonApp/Sources/Services/DaemonManager.swift
@@ -179,6 +179,8 @@ final class DaemonManager: ObservableObject {
         <dict>
             <key>Label</key>
             <string>\(serviceLabel)</string>
+            <key>AssociatedBundleIdentifiers</key>
+            <string>ac.hola.coulson</string>
             <key>Program</key>
             <string>\(daemonPath)</string>
             <key>ProgramArguments</key>

--- a/crates/coulson/src/main.rs
+++ b/crates/coulson/src/main.rs
@@ -3582,6 +3582,8 @@ fn setup_forward_daemon(cfg: &CoulsonConfig, force: bool) -> anyhow::Result<()> 
 <dict>
     <key>Label</key>
     <string>com.coulson.forward</string>
+    <key>AssociatedBundleIdentifiers</key>
+    <string>ac.hola.coulson</string>
     <key>ProgramArguments</key>
     <array>
 {args}


### PR DESCRIPTION
## Summary

- associate the per-user Coulson LaunchAgent with the main app bundle
- associate the system-wide forwarding LaunchDaemon with the main app bundle
- make System Settings show Coulson instead of the signing team name for newly registered background items

## Root cause

The legacy launchd property lists did not include `AssociatedBundleIdentifiers`, so macOS grouped both jobs under the signing certificate developer name.

## Verification

- `mise exec -- cargo test -p coulson` — 265 tests passed
- `mise exec -- swiftc -frontend -parse CoulsonApp/Sources/Services/DaemonManager.swift`
- `git diff --check`
- verified both live plist variants are accepted by launchd and reported by BTM with `Assoc. Bundle IDs: [ ac.hola.coulson ]`